### PR TITLE
feat: 로컬 개발 환경용 docker-compose 추가

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  postgres:
+    image: postgres:17.6
+    container_name: lol-postgres
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: 1234
+      POSTGRES_DB: postgres
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+  rabbitmq:
+    image: rabbitmq:3.13-management
+    container_name: lol-rabbitmq
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    environment:
+      RABBITMQ_DEFAULT_USER: guest
+      RABBITMQ_DEFAULT_PASS: guest
+
+  redis:
+    image: redis:latest
+    container_name: lol-redis
+    ports:
+      - "6379:6379"
+
+volumes:
+  postgres-data:


### PR DESCRIPTION
## Summary
- 로컬 개발 환경에서 사용할 인프라 서비스(PostgreSQL, RabbitMQ, Redis)를 docker-compose로 구성
- `application-*.yml`의 local 프로파일 설정(포트, 인증 정보)과 일치하도록 작성
- PostgreSQL 데이터 영속성을 위한 named volume 설정

## Test plan
- [ ] `docker compose -f docker/docker-compose.yml up -d`로 컨테이너 정상 실행 확인
- [ ] PostgreSQL `localhost:5432` 접속 확인 (postgres/1234)
- [ ] RabbitMQ `localhost:5672` 접속 및 Management UI(`localhost:15672`) 확인
- [ ] Redis `localhost:6379` 접속 확인
- [ ] `./gradlew :app:bootRun -Dspring.profiles.active=local`로 애플리케이션 정상 기동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)