### PR TITLE
feat: 매치 타임라인 벌크 저장 및 소환사 갱신 리팩토링

### DIFF
--- a/core/domain/src/main/java/com/mmrtr/lol/domain/summoner/domain/Summoner.java
+++ b/core/domain/src/main/java/com/mmrtr/lol/domain/summoner/domain/Summoner.java
@@ -58,8 +58,8 @@ public class Summoner {
 
     public void initSummoner() {
         revisionInfo = new RevisionInfo(
-                LocalDateTime.of(2020, 1, 1, 0, 0),
-                LocalDateTime.of(2020, 1, 1, 0, 0)
+                LocalDateTime.of(2026, 1, 1, 0, 0),
+                LocalDateTime.of(2026, 1, 1, 0, 0)
         );
     }
 }

--- a/core/domain/src/main/java/com/mmrtr/lol/domain/summoner/service/usecase/SaveSummonerDataUseCase.java
+++ b/core/domain/src/main/java/com/mmrtr/lol/domain/summoner/service/usecase/SaveSummonerDataUseCase.java
@@ -32,27 +32,21 @@ public class SaveSummonerDataUseCase {
                     .tier(leagueInfo.getTier())
                     .build());
 
-            LeagueSummoner savedLeagueSummoner = leagueSummonerRepositoryPort
-                    .findBy(summoner.getPuuid(), leagueInfo.getLeagueId())
-                    .orElse(null);
-
-            if (savedLeagueSummoner == null) {
-                LeagueSummoner leagueSummoner = LeagueSummoner.builder()
-                        .puuid(summoner.getPuuid())
-                        .leagueId(leagueInfo.getLeagueId())
-                        .queue(leagueInfo.getQueueType())
-                        .tier(leagueInfo.getTier())
-                        .rank(leagueInfo.getRank())
-                        .leaguePoints(leagueInfo.getLeaguePoints())
-                        .wins(leagueInfo.getWins())
-                        .losses(leagueInfo.getLosses())
-                        .hotStreak(leagueInfo.isHotStreak())
-                        .veteran(leagueInfo.isVeteran())
-                        .freshBlood(leagueInfo.isFreshBlood())
-                        .inactive(leagueInfo.isInactive())
-                        .build();
-                leagueSummonerRepositoryPort.save(leagueSummoner);
-            }
+            LeagueSummoner leagueSummoner = LeagueSummoner.builder()
+                    .puuid(summoner.getPuuid())
+                    .leagueId(leagueInfo.getLeagueId())
+                    .queue(leagueInfo.getQueueType())
+                    .tier(leagueInfo.getTier())
+                    .rank(leagueInfo.getRank())
+                    .leaguePoints(leagueInfo.getLeaguePoints())
+                    .wins(leagueInfo.getWins())
+                    .losses(leagueInfo.getLosses())
+                    .hotStreak(leagueInfo.isHotStreak())
+                    .veteran(leagueInfo.isVeteran())
+                    .freshBlood(leagueInfo.isFreshBlood())
+                    .inactive(leagueInfo.isInactive())
+                    .build();
+            leagueSummonerRepositoryPort.save(leagueSummoner);
         }
     }
 }

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,3 +1,5 @@
+name: lol-repository
+
 services:
   postgres:
     image: postgres:18-alpine

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/entity/timeline/events/BuildingEventsEntity.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/entity/timeline/events/BuildingEventsEntity.java
@@ -20,6 +20,7 @@ public class BuildingEventsEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Comment("건물 이벤트 ID")
+    @Column(name = "building_event_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/entity/timeline/events/ChampionSpecialKillEventEntity.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/entity/timeline/events/ChampionSpecialKillEventEntity.java
@@ -20,6 +20,7 @@ public class ChampionSpecialKillEventEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Comment("챔피언 특수 킬 이벤트 ID")
+    @Column(name = "champion_special_kill_event_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/entity/timeline/events/GameEventsEntity.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/entity/timeline/events/GameEventsEntity.java
@@ -19,6 +19,7 @@ public class GameEventsEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Comment("게임 이벤트 ID")
+    @Column(name = "game_event_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/entity/timeline/events/ItemEventsEntity.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/entity/timeline/events/ItemEventsEntity.java
@@ -18,6 +18,7 @@ public class ItemEventsEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Comment("아이템 이벤트 ID")
+    @Column(name = "item_event_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/entity/timeline/events/KillEventsEntity.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/entity/timeline/events/KillEventsEntity.java
@@ -20,6 +20,7 @@ public class KillEventsEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Comment("킬 이벤트 ID")
+    @Column(name = "kill_event_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/entity/timeline/events/LevelEventsEntity.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/entity/timeline/events/LevelEventsEntity.java
@@ -19,6 +19,7 @@ public class LevelEventsEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Comment("레벨 이벤트 ID")
+    @Column(name = "level_event_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/entity/timeline/events/SkillEventsEntity.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/entity/timeline/events/SkillEventsEntity.java
@@ -19,6 +19,7 @@ public class SkillEventsEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Comment("스킬 이벤트 ID")
+    @Column(name = "skill_event_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/entity/timeline/events/TurretPlateDestroyedEventEntity.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/entity/timeline/events/TurretPlateDestroyedEventEntity.java
@@ -20,6 +20,7 @@ public class TurretPlateDestroyedEventEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Comment("포탑 방벽 파괴 이벤트 ID")
+    @Column(name = "turret_plate_destroyed_event_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/entity/timeline/events/WardEventsEntity.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/entity/timeline/events/WardEventsEntity.java
@@ -19,6 +19,7 @@ public class WardEventsEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Comment("와드 이벤트 ID")
+    @Column(name = "ward_event_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/repository/MatchRepositoryImpl.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/repository/MatchRepositoryImpl.java
@@ -51,7 +51,7 @@ public class MatchRepositoryImpl {
     public String insertSql() {
         return " INSERT INTO \"match\" (" +
                 "match_id," +
-                "date_version," +
+                "data_version," +
                 "end_of_game_result," +
                 "game_creation," +
                 "game_duration," +
@@ -72,7 +72,7 @@ public class MatchRepositoryImpl {
                 "game_start_datetime" +
                 ") VALUES (" +
                 ":matchId," +
-                ":dateVersion," +
+                ":dataVersion," +
                 ":endOfGameResult," +
                 ":gameCreation," +
                 ":gameDuration," +

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/repository/TimeLineRepositoryImpl.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/repository/TimeLineRepositoryImpl.java
@@ -1,0 +1,342 @@
+package com.mmrtr.lol.infra.persistence.match.repository;
+
+import com.mmrtr.lol.infra.persistence.match.entity.timeline.ParticipantFrameEntity;
+import com.mmrtr.lol.infra.persistence.match.entity.timeline.TimeLineEventEntity;
+import com.mmrtr.lol.infra.persistence.match.entity.timeline.events.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class TimeLineRepositoryImpl {
+
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    public void bulkSaveTimeLineEvents(List<TimeLineEventEntity> entities) {
+        if (entities.isEmpty()) return;
+
+        String sql = "INSERT INTO time_line_event (match_id, timestamp) " +
+                "VALUES (:matchId, :timestamp) " +
+                "ON CONFLICT (match_id, timestamp) DO NOTHING";
+
+        SqlParameterSource[] params = entities.stream()
+                .map(e -> new MapSqlParameterSource()
+                        .addValue("matchId", e.getMatchEntity().getMatchId())
+                        .addValue("timestamp", e.getTimestamp()))
+                .toArray(SqlParameterSource[]::new);
+
+        jdbcTemplate.batchUpdate(sql, params);
+    }
+
+    public void bulkSaveParticipantFrames(List<ParticipantFrameEntity> entities) {
+        if (entities.isEmpty()) return;
+
+        String sql = "INSERT INTO participant_frame (" +
+                "match_id, timestamp, participant_id, " +
+                "ability_haste, ability_power, armor, armor_pen, armor_pen_percent, " +
+                "attack_damage, attack_speed, bonus_armor_pen_percent, bonus_magic_pen_percent, " +
+                "cc_reduction, cooldown_reduction, health, health_max, health_regen, " +
+                "lifesteal, magic_pen, magic_pen_percent, magic_resist, movement_speed, " +
+                "omnivamp, physical_vamp, power, power_max, power_regen, spell_vamp, " +
+                "current_gold, gold_per_second, jungle_minions_killed, level, minions_killed, " +
+                "time_enemy_spent_controlled, total_gold, xp, " +
+                "magic_damage_done, magic_damage_done_to_champions, magic_damage_taken, " +
+                "physical_damage_done, physical_damage_done_to_champions, physical_damage_taken, " +
+                "total_damage_done, total_damage_done_to_champions, total_damage_taken, " +
+                "true_damage_done, true_damage_done_to_champions, true_damage_taken, " +
+                "x, y" +
+                ") VALUES (" +
+                ":matchId, :timestamp, :participantId, " +
+                ":abilityHaste, :abilityPower, :armor, :armorPen, :armorPenPercent, " +
+                ":attackDamage, :attackSpeed, :bonusArmorPenPercent, :bonusMagicPenPercent, " +
+                ":ccReduction, :cooldownReduction, :health, :healthMax, :healthRegen, " +
+                ":lifesteal, :magicPen, :magicPenPercent, :magicResist, :movementSpeed, " +
+                ":omnivamp, :physicalVamp, :power, :powerMax, :powerRegen, :spellVamp, " +
+                ":currentGold, :goldPerSecond, :jungleMinionsKilled, :level, :minionsKilled, " +
+                ":timeEnemySpentControlled, :totalGold, :xp, " +
+                ":magicDamageDone, :magicDamageDoneToChampions, :magicDamageTaken, " +
+                ":physicalDamageDone, :physicalDamageDoneToChampions, :physicalDamageTaken, " +
+                ":totalDamageDone, :totalDamageDoneToChampions, :totalDamageTaken, " +
+                ":trueDamageDone, :trueDamageDoneToChampions, :trueDamageTaken, " +
+                ":x, :y" +
+                ") ON CONFLICT (match_id, timestamp, participant_id) DO NOTHING";
+
+        SqlParameterSource[] params = entities.stream()
+                .map(e -> new MapSqlParameterSource()
+                        .addValue("matchId", e.getMatchEntity().getMatchId())
+                        .addValue("timestamp", e.getTimestamp())
+                        .addValue("participantId", e.getParticipantId())
+                        .addValue("abilityHaste", e.getChampionStats().getAbilityHaste())
+                        .addValue("abilityPower", e.getChampionStats().getAbilityPower())
+                        .addValue("armor", e.getChampionStats().getArmor())
+                        .addValue("armorPen", e.getChampionStats().getArmorPen())
+                        .addValue("armorPenPercent", e.getChampionStats().getArmorPenPercent())
+                        .addValue("attackDamage", e.getChampionStats().getAttackDamage())
+                        .addValue("attackSpeed", e.getChampionStats().getAttackSpeed())
+                        .addValue("bonusArmorPenPercent", e.getChampionStats().getBonusArmorPenPercent())
+                        .addValue("bonusMagicPenPercent", e.getChampionStats().getBonusMagicPenPercent())
+                        .addValue("ccReduction", e.getChampionStats().getCcReduction())
+                        .addValue("cooldownReduction", e.getChampionStats().getCooldownReduction())
+                        .addValue("health", e.getChampionStats().getHealth())
+                        .addValue("healthMax", e.getChampionStats().getHealthMax())
+                        .addValue("healthRegen", e.getChampionStats().getHealthRegen())
+                        .addValue("lifesteal", e.getChampionStats().getLifesteal())
+                        .addValue("magicPen", e.getChampionStats().getMagicPen())
+                        .addValue("magicPenPercent", e.getChampionStats().getMagicPenPercent())
+                        .addValue("magicResist", e.getChampionStats().getMagicResist())
+                        .addValue("movementSpeed", e.getChampionStats().getMovementSpeed())
+                        .addValue("omnivamp", e.getChampionStats().getOmnivamp())
+                        .addValue("physicalVamp", e.getChampionStats().getPhysicalVamp())
+                        .addValue("power", e.getChampionStats().getPower())
+                        .addValue("powerMax", e.getChampionStats().getPowerMax())
+                        .addValue("powerRegen", e.getChampionStats().getPowerRegen())
+                        .addValue("spellVamp", e.getChampionStats().getSpellVamp())
+                        .addValue("currentGold", e.getCurrentGold())
+                        .addValue("goldPerSecond", e.getGoldPerSecond())
+                        .addValue("jungleMinionsKilled", e.getJungleMinionsKilled())
+                        .addValue("level", e.getLevel())
+                        .addValue("minionsKilled", e.getMinionsKilled())
+                        .addValue("timeEnemySpentControlled", e.getTimeEnemySpentControlled())
+                        .addValue("totalGold", e.getTotalGold())
+                        .addValue("xp", e.getXp())
+                        .addValue("magicDamageDone", e.getDamageStats().getMagicDamageDone())
+                        .addValue("magicDamageDoneToChampions", e.getDamageStats().getMagicDamageDoneToChampions())
+                        .addValue("magicDamageTaken", e.getDamageStats().getMagicDamageTaken())
+                        .addValue("physicalDamageDone", e.getDamageStats().getPhysicalDamageDone())
+                        .addValue("physicalDamageDoneToChampions", e.getDamageStats().getPhysicalDamageDoneToChampions())
+                        .addValue("physicalDamageTaken", e.getDamageStats().getPhysicalDamageTaken())
+                        .addValue("totalDamageDone", e.getDamageStats().getTotalDamageDone())
+                        .addValue("totalDamageDoneToChampions", e.getDamageStats().getTotalDamageDoneToChampions())
+                        .addValue("totalDamageTaken", e.getDamageStats().getTotalDamageTaken())
+                        .addValue("trueDamageDone", e.getDamageStats().getTrueDamageDone())
+                        .addValue("trueDamageDoneToChampions", e.getDamageStats().getTrueDamageDoneToChampions())
+                        .addValue("trueDamageTaken", e.getDamageStats().getTrueDamageTaken())
+                        .addValue("x", e.getPosition().getX())
+                        .addValue("y", e.getPosition().getY()))
+                .toArray(SqlParameterSource[]::new);
+
+        jdbcTemplate.batchUpdate(sql, params);
+    }
+
+    public void bulkSaveItemEvents(List<ItemEventsEntity> entities) {
+        if (entities.isEmpty()) return;
+
+        String sql = "INSERT INTO item_events (" +
+                "match_id, timeline_timestamp, item_id, participant_id, timestamp, type, after_id, before_id, gold_gain" +
+                ") VALUES (" +
+                ":matchId, :timelineTimestamp, :itemId, :participantId, :timestamp, :type, :afterId, :beforeId, :goldGain)";
+
+        SqlParameterSource[] params = entities.stream()
+                .map(e -> new MapSqlParameterSource()
+                        .addValue("matchId", e.getTimeLineEvent().getMatchEntity().getMatchId())
+                        .addValue("timelineTimestamp", e.getTimeLineEvent().getTimestamp())
+                        .addValue("itemId", e.getItemId())
+                        .addValue("participantId", e.getParticipantId())
+                        .addValue("timestamp", e.getTimestamp())
+                        .addValue("type", e.getType())
+                        .addValue("afterId", e.getAfterId())
+                        .addValue("beforeId", e.getBeforeId())
+                        .addValue("goldGain", e.getGoldGain()))
+                .toArray(SqlParameterSource[]::new);
+
+        jdbcTemplate.batchUpdate(sql, params);
+    }
+
+    public void bulkSaveSkillEvents(List<SkillEventsEntity> entities) {
+        if (entities.isEmpty()) return;
+
+        String sql = "INSERT INTO skill_events (" +
+                "match_id, timeline_timestamp, skill_slot, participant_id, level_up_type, timestamp, type" +
+                ") VALUES (" +
+                ":matchId, :timelineTimestamp, :skillSlot, :participantId, :levelUpType, :timestamp, :type)";
+
+        SqlParameterSource[] params = entities.stream()
+                .map(e -> new MapSqlParameterSource()
+                        .addValue("matchId", e.getTimeLineEvent().getMatchEntity().getMatchId())
+                        .addValue("timelineTimestamp", e.getTimeLineEvent().getTimestamp())
+                        .addValue("skillSlot", e.getSkillSlot())
+                        .addValue("participantId", e.getParticipantId())
+                        .addValue("levelUpType", e.getLevelUpType())
+                        .addValue("timestamp", e.getTimestamp())
+                        .addValue("type", e.getType()))
+                .toArray(SqlParameterSource[]::new);
+
+        jdbcTemplate.batchUpdate(sql, params);
+    }
+
+    public void bulkSaveKillEvents(List<KillEventsEntity> entities) {
+        if (entities.isEmpty()) return;
+
+        String sql = "INSERT INTO kill_events (" +
+                "match_id, timeline_timestamp, assisting_participant_ids, bounty, kill_streak_length, " +
+                "killer_id, x, y, shutdown_bounty, victim_id, timestamp, type" +
+                ") VALUES (" +
+                ":matchId, :timelineTimestamp, :assistingParticipantIds, :bounty, :killStreakLength, " +
+                ":killerId, :x, :y, :shutdownBounty, :victimId, :timestamp, :type)";
+
+        SqlParameterSource[] params = entities.stream()
+                .map(e -> new MapSqlParameterSource()
+                        .addValue("matchId", e.getTimeLineEvent().getMatchEntity().getMatchId())
+                        .addValue("timelineTimestamp", e.getTimeLineEvent().getTimestamp())
+                        .addValue("assistingParticipantIds", e.getAssistingParticipantIds())
+                        .addValue("bounty", e.getBounty())
+                        .addValue("killStreakLength", e.getKillStreakLength())
+                        .addValue("killerId", e.getKillerId())
+                        .addValue("x", e.getPosition().getX())
+                        .addValue("y", e.getPosition().getY())
+                        .addValue("shutdownBounty", e.getShutdownBounty())
+                        .addValue("victimId", e.getVictimId())
+                        .addValue("timestamp", e.getTimestamp())
+                        .addValue("type", e.getType()))
+                .toArray(SqlParameterSource[]::new);
+
+        jdbcTemplate.batchUpdate(sql, params);
+    }
+
+    public void bulkSaveBuildingEvents(List<BuildingEventsEntity> entities) {
+        if (entities.isEmpty()) return;
+
+        String sql = "INSERT INTO building_events (" +
+                "match_id, timeline_timestamp, assisting_participant_ids, bounty, building_type, " +
+                "killer_id, lane_type, x, y, team_id, timestamp, tower_type, type" +
+                ") VALUES (" +
+                ":matchId, :timelineTimestamp, :assistingParticipantIds, :bounty, :buildingType, " +
+                ":killerId, :laneType, :x, :y, :teamId, :timestamp, :towerType, :type)";
+
+        SqlParameterSource[] params = entities.stream()
+                .map(e -> new MapSqlParameterSource()
+                        .addValue("matchId", e.getTimeLineEvent().getMatchEntity().getMatchId())
+                        .addValue("timelineTimestamp", e.getTimeLineEvent().getTimestamp())
+                        .addValue("assistingParticipantIds", e.getAssistingParticipantIds())
+                        .addValue("bounty", e.getBounty())
+                        .addValue("buildingType", e.getBuildingType())
+                        .addValue("killerId", e.getKillerId())
+                        .addValue("laneType", e.getLaneType())
+                        .addValue("x", e.getPositionValue() != null ? e.getPositionValue().getX() : 0)
+                        .addValue("y", e.getPositionValue() != null ? e.getPositionValue().getY() : 0)
+                        .addValue("teamId", e.getTeamId())
+                        .addValue("timestamp", e.getTimestamp())
+                        .addValue("towerType", e.getTowerType())
+                        .addValue("type", e.getType()))
+                .toArray(SqlParameterSource[]::new);
+
+        jdbcTemplate.batchUpdate(sql, params);
+    }
+
+    public void bulkSaveWardEvents(List<WardEventsEntity> entities) {
+        if (entities.isEmpty()) return;
+
+        String sql = "INSERT INTO ward_events (" +
+                "match_id, timeline_timestamp, participant_id, ward_type, timestamp, type" +
+                ") VALUES (" +
+                ":matchId, :timelineTimestamp, :participantId, :wardType, :timestamp, :type)";
+
+        SqlParameterSource[] params = entities.stream()
+                .map(e -> new MapSqlParameterSource()
+                        .addValue("matchId", e.getTimeLineEvent().getMatchEntity().getMatchId())
+                        .addValue("timelineTimestamp", e.getTimeLineEvent().getTimestamp())
+                        .addValue("participantId", e.getParticipantId())
+                        .addValue("wardType", e.getWardType())
+                        .addValue("timestamp", e.getTimestamp())
+                        .addValue("type", e.getType()))
+                .toArray(SqlParameterSource[]::new);
+
+        jdbcTemplate.batchUpdate(sql, params);
+    }
+
+    public void bulkSaveGameEvents(List<GameEventsEntity> entities) {
+        if (entities.isEmpty()) return;
+
+        String sql = "INSERT INTO game_events (" +
+                "match_id, timeline_timestamp, timestamp, game_id, real_timestamp, winning_team, type" +
+                ") VALUES (" +
+                ":matchId, :timelineTimestamp, :timestamp, :gameId, :realTimestamp, :winningTeam, :type)";
+
+        SqlParameterSource[] params = entities.stream()
+                .map(e -> new MapSqlParameterSource()
+                        .addValue("matchId", e.getTimeLineEvent().getMatchEntity().getMatchId())
+                        .addValue("timelineTimestamp", e.getTimeLineEvent().getTimestamp())
+                        .addValue("timestamp", e.getTimestamp())
+                        .addValue("gameId", e.getGameId())
+                        .addValue("realTimestamp", e.getRealTimestamp())
+                        .addValue("winningTeam", e.getWinningTeam())
+                        .addValue("type", e.getType()))
+                .toArray(SqlParameterSource[]::new);
+
+        jdbcTemplate.batchUpdate(sql, params);
+    }
+
+    public void bulkSaveLevelEvents(List<LevelEventsEntity> entities) {
+        if (entities.isEmpty()) return;
+
+        String sql = "INSERT INTO level_events (" +
+                "match_id, timeline_timestamp, level, participant_id, timestamp, type" +
+                ") VALUES (" +
+                ":matchId, :timelineTimestamp, :level, :participantId, :timestamp, :type)";
+
+        SqlParameterSource[] params = entities.stream()
+                .map(e -> new MapSqlParameterSource()
+                        .addValue("matchId", e.getTimeLineEvent().getMatchEntity().getMatchId())
+                        .addValue("timelineTimestamp", e.getTimeLineEvent().getTimestamp())
+                        .addValue("level", e.getLevel())
+                        .addValue("participantId", e.getParticipantId())
+                        .addValue("timestamp", e.getTimestamp())
+                        .addValue("type", e.getType()))
+                .toArray(SqlParameterSource[]::new);
+
+        jdbcTemplate.batchUpdate(sql, params);
+    }
+
+    public void bulkSaveChampionSpecialKillEvents(List<ChampionSpecialKillEventEntity> entities) {
+        if (entities.isEmpty()) return;
+
+        String sql = "INSERT INTO champion_special_kill_event (" +
+                "match_id, timeline_timestamp, kill_type, killer_id, multi_kill_length, x, y, timestamp, type" +
+                ") VALUES (" +
+                ":matchId, :timelineTimestamp, :killType, :killerId, :multiKillLength, :x, :y, :timestamp, :type)";
+
+        SqlParameterSource[] params = entities.stream()
+                .map(e -> new MapSqlParameterSource()
+                        .addValue("matchId", e.getTimeLineEvent().getMatchEntity().getMatchId())
+                        .addValue("timelineTimestamp", e.getTimeLineEvent().getTimestamp())
+                        .addValue("killType", e.getKillType())
+                        .addValue("killerId", e.getKillerId())
+                        .addValue("multiKillLength", e.getMultiKillLength())
+                        .addValue("x", e.getPositionValue() != null ? e.getPositionValue().getX() : 0)
+                        .addValue("y", e.getPositionValue() != null ? e.getPositionValue().getY() : 0)
+                        .addValue("timestamp", e.getTimestamp())
+                        .addValue("type", e.getType()))
+                .toArray(SqlParameterSource[]::new);
+
+        jdbcTemplate.batchUpdate(sql, params);
+    }
+
+    public void bulkSaveTurretPlateDestroyedEvents(List<TurretPlateDestroyedEventEntity> entities) {
+        if (entities.isEmpty()) return;
+
+        String sql = "INSERT INTO turret_plate_destroyed_event (" +
+                "match_id, timeline_timestamp, killer_id, lane_type, x, y, team_id, timestamp, type" +
+                ") VALUES (" +
+                ":matchId, :timelineTimestamp, :killerId, :laneType, :x, :y, :teamId, :timestamp, :type)";
+
+        SqlParameterSource[] params = entities.stream()
+                .map(e -> new MapSqlParameterSource()
+                        .addValue("matchId", e.getTimeLineEvent().getMatchEntity().getMatchId())
+                        .addValue("timelineTimestamp", e.getTimeLineEvent().getTimestamp())
+                        .addValue("killerId", e.getKillerId())
+                        .addValue("laneType", e.getLaneType())
+                        .addValue("x", e.getPositionValue() != null ? e.getPositionValue().getX() : 0)
+                        .addValue("y", e.getPositionValue() != null ? e.getPositionValue().getY() : 0)
+                        .addValue("teamId", e.getTeamId())
+                        .addValue("timestamp", e.getTimestamp())
+                        .addValue("type", e.getType()))
+                .toArray(SqlParameterSource[]::new);
+
+        jdbcTemplate.batchUpdate(sql, params);
+    }
+}

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/service/TimeLineService.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/service/TimeLineService.java
@@ -1,12 +1,321 @@
 package com.mmrtr.lol.infra.persistence.match.service;
 
+import com.mmrtr.lol.infra.persistence.match.entity.MatchEntity;
+import com.mmrtr.lol.infra.persistence.match.entity.timeline.ParticipantFrameEntity;
+import com.mmrtr.lol.infra.persistence.match.entity.timeline.TimeLineEventEntity;
+import com.mmrtr.lol.infra.persistence.match.entity.timeline.events.*;
+import com.mmrtr.lol.infra.persistence.match.entity.timeline.value.ChampionStatsValue;
+import com.mmrtr.lol.infra.persistence.match.entity.timeline.value.DamageStatsValue;
+import com.mmrtr.lol.infra.persistence.match.entity.timeline.value.PositionValue;
+import com.mmrtr.lol.infra.persistence.match.repository.TimeLineRepositoryImpl;
+import com.mmrtr.lol.infra.riot.dto.match_timeline.*;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TimeLineService {
 
+    private final TimeLineRepositoryImpl timeLineRepository;
 
+    @Transactional
+    public void saveAll(List<MatchEntity> matchEntities, List<TimelineDto> timelineDtos) {
+        Map<String, MatchEntity> matchEntityMap = matchEntities.stream()
+                .collect(Collectors.toMap(MatchEntity::getMatchId, Function.identity()));
 
+        List<TimeLineEventEntity> allTimeLineEvents = new ArrayList<>();
+        List<ParticipantFrameEntity> allParticipantFrames = new ArrayList<>();
+        List<ItemEventsEntity> allItemEvents = new ArrayList<>();
+        List<SkillEventsEntity> allSkillEvents = new ArrayList<>();
+        List<KillEventsEntity> allKillEvents = new ArrayList<>();
+        List<BuildingEventsEntity> allBuildingEvents = new ArrayList<>();
+        List<WardEventsEntity> allWardEvents = new ArrayList<>();
+        List<GameEventsEntity> allGameEvents = new ArrayList<>();
+        List<LevelEventsEntity> allLevelEvents = new ArrayList<>();
+        List<ChampionSpecialKillEventEntity> allChampionSpecialKillEvents = new ArrayList<>();
+        List<TurretPlateDestroyedEventEntity> allTurretPlateDestroyedEvents = new ArrayList<>();
+
+        for (TimelineDto timelineDto : timelineDtos) {
+            if (timelineDto == null || timelineDto.getInfo() == null) continue;
+
+            String matchId = timelineDto.getMetadata().getMatchId();
+            MatchEntity matchEntity = matchEntityMap.get(matchId);
+            if (matchEntity == null) continue;
+
+            List<FramesTimeLineDto> frames = timelineDto.getInfo().getFrames();
+            if (frames == null) continue;
+
+            for (FramesTimeLineDto frame : frames) {
+                TimeLineEventEntity timeLineEvent = TimeLineEventEntity.builder()
+                        .matchEntity(matchEntity)
+                        .timestamp(frame.getTimestamp())
+                        .build();
+                allTimeLineEvents.add(timeLineEvent);
+
+                // Participant frames
+                ParticipantFramesDto participantFrames = frame.getParticipantFrames();
+                if (participantFrames != null) {
+                    List<ParticipantFrameDto> frameDtos = toParticipantFrameList(participantFrames);
+                    for (ParticipantFrameDto pf : frameDtos) {
+                        allParticipantFrames.add(toParticipantFrameEntity(matchEntity, frame.getTimestamp(), pf));
+                    }
+                }
+
+                // Events classification
+                List<EventsTimeLineDto> events = frame.getEvents();
+                if (events == null) continue;
+
+                for (EventsTimeLineDto event : events) {
+                    String type = event.getType();
+                    if (type == null) continue;
+
+                    switch (type) {
+                        case "ITEM_PURCHASED", "ITEM_SOLD", "ITEM_DESTROYED", "ITEM_UNDO" ->
+                                allItemEvents.add(toItemEventsEntity(timeLineEvent, event));
+                        case "SKILL_LEVEL_UP" ->
+                                allSkillEvents.add(toSkillEventsEntity(timeLineEvent, event));
+                        case "CHAMPION_KILL" ->
+                                allKillEvents.add(toKillEventsEntity(timeLineEvent, event));
+                        case "BUILDING_KILL", "ELITE_MONSTER_KILL" ->
+                                allBuildingEvents.add(toBuildingEventsEntity(timeLineEvent, event));
+                        case "WARD_PLACED", "WARD_KILL" ->
+                                allWardEvents.add(toWardEventsEntity(timeLineEvent, event));
+                        case "GAME_END" ->
+                                allGameEvents.add(toGameEventsEntity(timeLineEvent, event, timelineDto));
+                        case "LEVEL_UP" ->
+                                allLevelEvents.add(toLevelEventsEntity(timeLineEvent, event));
+                        case "CHAMPION_SPECIAL_KILL" ->
+                                allChampionSpecialKillEvents.add(toChampionSpecialKillEventEntity(timeLineEvent, event));
+                        case "TURRET_PLATE_DESTROYED" ->
+                                allTurretPlateDestroyedEvents.add(toTurretPlateDestroyedEventEntity(timeLineEvent, event));
+                        default -> { }
+                    }
+                }
+            }
+        }
+
+        timeLineRepository.bulkSaveTimeLineEvents(allTimeLineEvents);
+        timeLineRepository.bulkSaveParticipantFrames(allParticipantFrames);
+        timeLineRepository.bulkSaveItemEvents(allItemEvents);
+        timeLineRepository.bulkSaveSkillEvents(allSkillEvents);
+        timeLineRepository.bulkSaveKillEvents(allKillEvents);
+        timeLineRepository.bulkSaveBuildingEvents(allBuildingEvents);
+        timeLineRepository.bulkSaveWardEvents(allWardEvents);
+        timeLineRepository.bulkSaveGameEvents(allGameEvents);
+        timeLineRepository.bulkSaveLevelEvents(allLevelEvents);
+        timeLineRepository.bulkSaveChampionSpecialKillEvents(allChampionSpecialKillEvents);
+        timeLineRepository.bulkSaveTurretPlateDestroyedEvents(allTurretPlateDestroyedEvents);
+    }
+
+    private List<ParticipantFrameDto> toParticipantFrameList(ParticipantFramesDto frames) {
+        List<ParticipantFrameDto> list = new ArrayList<>();
+        if (frames.getP1() != null) list.add(frames.getP1());
+        if (frames.getP2() != null) list.add(frames.getP2());
+        if (frames.getP3() != null) list.add(frames.getP3());
+        if (frames.getP4() != null) list.add(frames.getP4());
+        if (frames.getP5() != null) list.add(frames.getP5());
+        if (frames.getP6() != null) list.add(frames.getP6());
+        if (frames.getP7() != null) list.add(frames.getP7());
+        if (frames.getP8() != null) list.add(frames.getP8());
+        if (frames.getP9() != null) list.add(frames.getP9());
+        if (frames.getP10() != null) list.add(frames.getP10());
+        return list;
+    }
+
+    private ParticipantFrameEntity toParticipantFrameEntity(MatchEntity matchEntity, int timestamp, ParticipantFrameDto dto) {
+        ChampionStatsDto cs = dto.getChampionStats();
+        DamageStatsDto ds = dto.getDamageStats();
+        PositionDto pos = dto.getPosition();
+
+        return ParticipantFrameEntity.builder()
+                .matchEntity(matchEntity)
+                .timestamp(timestamp)
+                .participantId(dto.getParticipantId())
+                .championStats(cs != null ? ChampionStatsValue.builder()
+                        .abilityHaste(cs.getAbilityHaste())
+                        .abilityPower(cs.getAbilityPower())
+                        .armor(cs.getArmor())
+                        .armorPen(cs.getArmorPen())
+                        .armorPenPercent(cs.getArmorPenPercent())
+                        .attackDamage(cs.getAttackDamage())
+                        .attackSpeed(cs.getAttackSpeed())
+                        .bonusArmorPenPercent(cs.getBonusArmorPenPercent())
+                        .bonusMagicPenPercent(cs.getBonusMagicPenPercent())
+                        .ccReduction(cs.getCcReduction())
+                        .cooldownReduction(cs.getCooldownReduction())
+                        .health(cs.getHealth())
+                        .healthMax(cs.getHealthMax())
+                        .healthRegen(cs.getHealthRegen())
+                        .lifesteal(cs.getLifesteal())
+                        .magicPen(cs.getMagicPen())
+                        .magicPenPercent(cs.getMagicPenPercent())
+                        .magicResist(cs.getMagicResist())
+                        .movementSpeed(cs.getMovementSpeed())
+                        .omnivamp(cs.getOmnivamp())
+                        .physicalVamp(cs.getPhysicalVamp())
+                        .power(cs.getPower())
+                        .powerMax(cs.getPowerMax())
+                        .powerRegen(cs.getPowerRegen())
+                        .spellVamp(cs.getSpellVamp())
+                        .build() : new ChampionStatsValue())
+                .currentGold(dto.getCurrentGold())
+                .damageStats(ds != null ? DamageStatsValue.builder()
+                        .magicDamageDone(ds.getMagicDamageDone())
+                        .magicDamageDoneToChampions(ds.getMagicDamageDoneToChampions())
+                        .magicDamageTaken(ds.getMagicDamageTaken())
+                        .physicalDamageDone(ds.getPhysicalDamageDone())
+                        .physicalDamageDoneToChampions(ds.getPhysicalDamageDoneToChampions())
+                        .physicalDamageTaken(ds.getPhysicalDamageTaken())
+                        .totalDamageDone(ds.getTotalDamageDone())
+                        .totalDamageDoneToChampions(ds.getTotalDamageDoneToChampions())
+                        .totalDamageTaken(ds.getTotalDamageTaken())
+                        .trueDamageDone(ds.getTrueDamageDone())
+                        .trueDamageDoneToChampions(ds.getTrueDamageDoneToChampions())
+                        .trueDamageTaken(ds.getTrueDamageTaken())
+                        .build() : new DamageStatsValue())
+                .goldPerSecond(dto.getGoldPerSecond())
+                .jungleMinionsKilled(dto.getJungleMinionsKilled())
+                .level(dto.getLevel())
+                .minionsKilled(dto.getMinionsKilled())
+                .position(pos != null ? PositionValue.builder()
+                        .x(pos.getX())
+                        .y(pos.getY())
+                        .build() : new PositionValue())
+                .timeEnemySpentControlled(dto.getTimeEnemySpentControlled())
+                .totalGold(dto.getTotalGold())
+                .xp(dto.getXp())
+                .build();
+    }
+
+    private ItemEventsEntity toItemEventsEntity(TimeLineEventEntity timeLineEvent, EventsTimeLineDto event) {
+        ItemEventsEntity entity = new ItemEventsEntity();
+        entity.setTimeLineEvent(timeLineEvent);
+        entity.setItemId(event.getItemId());
+        entity.setParticipantId(event.getParticipantId());
+        entity.setTimestamp(event.getTimestamp());
+        entity.setType(event.getType());
+        entity.setAfterId(event.getAfterId());
+        entity.setBeforeId(event.getBeforeId());
+        entity.setGoldGain(event.getGoldGain());
+        return entity;
+    }
+
+    private SkillEventsEntity toSkillEventsEntity(TimeLineEventEntity timeLineEvent, EventsTimeLineDto event) {
+        SkillEventsEntity entity = new SkillEventsEntity();
+        entity.setTimeLineEvent(timeLineEvent);
+        entity.setSkillSlot(event.getSkillSlot());
+        entity.setParticipantId(event.getParticipantId());
+        entity.setLevelUpType(event.getLevelUpType());
+        entity.setTimestamp(event.getTimestamp());
+        entity.setType(event.getType());
+        return entity;
+    }
+
+    private KillEventsEntity toKillEventsEntity(TimeLineEventEntity timeLineEvent, EventsTimeLineDto event) {
+        KillEventsEntity entity = new KillEventsEntity();
+        entity.setTimeLineEvent(timeLineEvent);
+        entity.setAssistingParticipantIds(convertAssistingIds(event.getAssistingParticipantIds()));
+        entity.setBounty(event.getBounty());
+        entity.setKillStreakLength(event.getKillStreakLength());
+        entity.setKillerId(event.getKillerId());
+        entity.setPosition(event.getPosition() != null
+                ? PositionValue.builder().x(event.getPosition().getX()).y(event.getPosition().getY()).build()
+                : new PositionValue());
+        entity.setShutdownBounty(0);
+        entity.setVictimId(event.getVictimId());
+        entity.setTimestamp(event.getTimestamp());
+        entity.setType(event.getType());
+        return entity;
+    }
+
+    private BuildingEventsEntity toBuildingEventsEntity(TimeLineEventEntity timeLineEvent, EventsTimeLineDto event) {
+        BuildingEventsEntity entity = new BuildingEventsEntity();
+        entity.setTimeLineEvent(timeLineEvent);
+        entity.setAssistingParticipantIds(convertAssistingIds(event.getAssistingParticipantIds()));
+        entity.setBounty(event.getBounty());
+        entity.setBuildingType(event.getBuildingType());
+        entity.setKillerId(event.getKillerId());
+        entity.setLaneType(event.getLaneType());
+        entity.setPositionValue(event.getPosition() != null
+                ? PositionValue.builder().x(event.getPosition().getX()).y(event.getPosition().getY()).build()
+                : new PositionValue());
+        entity.setTeamId(event.getTeamId());
+        entity.setTimestamp(event.getTimestamp());
+        entity.setTowerType(event.getTowerType());
+        entity.setType(event.getType());
+        return entity;
+    }
+
+    private WardEventsEntity toWardEventsEntity(TimeLineEventEntity timeLineEvent, EventsTimeLineDto event) {
+        WardEventsEntity entity = new WardEventsEntity();
+        entity.setTimeLineEvent(timeLineEvent);
+        entity.setParticipantId(event.getParticipantId());
+        entity.setWardType(event.getWardType());
+        entity.setTimestamp(event.getTimestamp());
+        entity.setType(event.getType());
+        return entity;
+    }
+
+    private GameEventsEntity toGameEventsEntity(TimeLineEventEntity timeLineEvent, EventsTimeLineDto event, TimelineDto timelineDto) {
+        GameEventsEntity entity = new GameEventsEntity();
+        entity.setTimeLineEvent(timeLineEvent);
+        entity.setTimestamp(event.getTimestamp());
+        entity.setGameId(timelineDto.getInfo().getGameId());
+        entity.setRealTimestamp(0L);
+        entity.setWinningTeam(0);
+        entity.setType(event.getType());
+        return entity;
+    }
+
+    private LevelEventsEntity toLevelEventsEntity(TimeLineEventEntity timeLineEvent, EventsTimeLineDto event) {
+        LevelEventsEntity entity = new LevelEventsEntity();
+        entity.setTimeLineEvent(timeLineEvent);
+        entity.setLevel(0);
+        entity.setParticipantId(event.getParticipantId());
+        entity.setTimestamp(event.getTimestamp());
+        entity.setType(event.getType());
+        return entity;
+    }
+
+    private ChampionSpecialKillEventEntity toChampionSpecialKillEventEntity(TimeLineEventEntity timeLineEvent, EventsTimeLineDto event) {
+        ChampionSpecialKillEventEntity entity = new ChampionSpecialKillEventEntity();
+        entity.setTimeLineEvent(timeLineEvent);
+        entity.setKillType(event.getKillType());
+        entity.setKillerId(event.getKillerId());
+        entity.setMultiKillLength(0);
+        entity.setPositionValue(event.getPosition() != null
+                ? PositionValue.builder().x(event.getPosition().getX()).y(event.getPosition().getY()).build()
+                : new PositionValue());
+        entity.setTimestamp(event.getTimestamp());
+        entity.setType(event.getType());
+        return entity;
+    }
+
+    private TurretPlateDestroyedEventEntity toTurretPlateDestroyedEventEntity(TimeLineEventEntity timeLineEvent, EventsTimeLineDto event) {
+        TurretPlateDestroyedEventEntity entity = new TurretPlateDestroyedEventEntity();
+        entity.setTimeLineEvent(timeLineEvent);
+        entity.setKillerId(event.getKillerId());
+        entity.setLaneType(event.getLaneType());
+        entity.setPositionValue(event.getPosition() != null
+                ? PositionValue.builder().x(event.getPosition().getX()).y(event.getPosition().getY()).build()
+                : new PositionValue());
+        entity.setTeamId(event.getTeamId());
+        entity.setTimestamp(event.getTimestamp());
+        entity.setType(event.getType());
+        return entity;
+    }
+
+    private String convertAssistingIds(List<Integer> ids) {
+        if (ids == null || ids.isEmpty()) return null;
+        return ids.stream().map(String::valueOf).collect(Collectors.joining(","));
+    }
 }

--- a/infra/persistence/src/main/resources/application-persistence.yml
+++ b/infra/persistence/src/main/resources/application-persistence.yml
@@ -16,13 +16,17 @@ spring:
     activate:
       on-profile: local
   datasource:
-    url: jdbc:postgresql://localhost:5432/postgres
+#    url: jdbc:postgresql://localhost:5432/postgres
+#    driver-class-name: org.postgresql.Driver
+#    username: postgres
+#    password: 1234
+    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
     driver-class-name: org.postgresql.Driver
-    username: postgres
-    password: 1234
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: false
     properties:
       hibernate:

--- a/infra/rabbitmq/src/main/java/com/mmrtr/lol/infra/rabbitmq/config/RabbitMqConfig.java
+++ b/infra/rabbitmq/src/main/java/com/mmrtr/lol/infra/rabbitmq/config/RabbitMqConfig.java
@@ -170,8 +170,8 @@ public class RabbitMqConfig {
         SimpleRabbitListenerContainerFactory simpleFactory = new SimpleRabbitListenerContainerFactory();
         configurer.configure(simpleFactory, factory);
 
-        simpleFactory.setConcurrentConsumers(10);
-        simpleFactory.setMaxConcurrentConsumers(10);
+        simpleFactory.setConcurrentConsumers(20);
+        simpleFactory.setMaxConcurrentConsumers(20);
 
         simpleFactory.setPrefetchCount(1);
 

--- a/infra/rabbitmq/src/main/java/com/mmrtr/lol/infra/rabbitmq/listener/SummonerRenewalListener.java
+++ b/infra/rabbitmq/src/main/java/com/mmrtr/lol/infra/rabbitmq/listener/SummonerRenewalListener.java
@@ -1,152 +1,42 @@
 package com.mmrtr.lol.infra.rabbitmq.listener;
 
-import com.mmrtr.lol.infra.persistence.match.entity.MatchEntity;
-import com.mmrtr.lol.infra.persistence.match.service.MatchService;
-import com.mmrtr.lol.domain.summoner.domain.Summoner;
-import com.mmrtr.lol.domain.summoner.domain.vo.LeagueInfo;
-import com.mmrtr.lol.domain.summoner.service.usecase.SaveSummonerDataUseCase;
-import com.mmrtr.lol.infra.rabbitmq.dto.SummonerMessage;
-import com.mmrtr.lol.infra.rabbitmq.dto.SummonerRenewalMessage;
-import com.mmrtr.lol.infra.redis.service.RedisLockHandler;
-import com.mmrtr.lol.infra.riot.dto.account.AccountDto;
-import com.mmrtr.lol.infra.riot.dto.league.LeagueEntryDto;
-import com.mmrtr.lol.infra.riot.dto.match.MatchDto;
-import com.mmrtr.lol.infra.riot.dto.summoner.SummonerDto;
-import com.mmrtr.lol.infra.riot.service.RiotApiService;
 import com.mmrtr.lol.common.type.Platform;
+import com.mmrtr.lol.infra.rabbitmq.dto.SummonerMessage;
+import com.mmrtr.lol.infra.rabbitmq.service.SummonerRenewalService;
+import com.mmrtr.lol.infra.redis.service.RedisLockHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
-import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class SummonerRenewalListener {
 
-    private final RabbitTemplate rabbitTemplate;
+    private static final Duration LOCK_TIMEOUT = Duration.ofMinutes(3L);
+
     private final RedisLockHandler redisLockHandler;
-    private final RiotApiService riotApiService;
-    private final MatchService matchService;
-    private final SaveSummonerDataUseCase saveSummonerDataUseCase;
-    private final Executor requestExecutor;
+    private final SummonerRenewalService summonerRenewalService;
 
     @RabbitListener(queues = "mmrtr.summoner", containerFactory = "simpleRabbitListenerContainerFactory")
-    @Transactional
     public void receiveSummonerMessageV2(@Payload SummonerMessage summonerMessage) {
         log.info("전적 갱신 요청 {}", summonerMessage);
         String puuid = summonerMessage.getPuuid();
-        if (!redisLockHandler.acquireLock(puuid, Duration.ofMinutes(3L))) {
+        if (!redisLockHandler.acquireLock(puuid, LOCK_TIMEOUT)) {
             log.info("이미 전적 갱신 진행 중 입니다. {}", puuid);
             return;
         }
 
-        // clickDate 갱신
-
-
-        long start = System.currentTimeMillis();
-        log.info("Lock 획득, 유저 전적 갱신 시작: {}", puuid);
-        Platform platform = Platform.valueOfName(summonerMessage.getPlatform());
-
-        CompletableFuture<SummonerDto> summonerDtoFuture = riotApiService.getSummonerByPuuid(puuid, platform, requestExecutor);
-        SummonerDto summonerDto = summonerDtoFuture.join();
-        assert summonerDto != null;
-        if (summonerMessage.getRevisionDate() == summonerDto.getRevisionDate()) {
-            log.info("revisionDate is same. No need to update.");
+        try {
+            Platform platform = Platform.valueOfName(summonerMessage.getPlatform());
+            summonerRenewalService.renewSummoner(puuid, platform);
+        } finally {
             redisLockHandler.deleteSummonerRenewal(puuid);
             redisLockHandler.releaseLock(puuid);
-            return;
         }
-
-        CompletableFuture<AccountDto> accountDtoFuture = riotApiService
-                .getAccountByPuuid(puuid, platform, requestExecutor);
-        CompletableFuture<Set<LeagueEntryDto>> leagueEntryDtoFuture = riotApiService
-                .getLeagueEntriesByPuuid(puuid, platform, requestExecutor);
-        CompletableFuture<List<String>> matchIdListFuture = riotApiService.getMatchListByPuuid(
-                puuid, platform, summonerMessage.getRevisionDate(), 0, 20, requestExecutor);
-
-        CompletableFuture<List<MatchDto>> matchListFuture = matchIdListFuture.thenCompose(matchIds -> {
-            if (matchIds.size() == 20) {
-                log.info("matchIds size is 20. send message for search more matchIds");
-                rabbitTemplate.convertAndSend(
-                        "renewal.topic.exchange",
-                        "renewal.match.find",
-                        new SummonerRenewalMessage(puuid,  platform.getPlatformId(), summonerMessage.getRevisionDate())
-                );
-            }
-
-            List<MatchEntity> matchList = matchService.findAllMatch(matchIds);
-            List<String> existMatchIds = matchList.stream().map(MatchEntity::getMatchId).toList();
-            List<String> filteredMatchIds = matchIds.stream().filter(matchId -> !existMatchIds.contains(matchId)).toList();
-
-            List<CompletableFuture<MatchDto>> matchAllOfFuture = filteredMatchIds.stream()
-                    .map(mathId -> riotApiService.getMatchById(mathId, platform, requestExecutor))
-                    .toList();
-
-            CompletableFuture<Void> allOfFuture = CompletableFuture.allOf(matchAllOfFuture.toArray(new CompletableFuture[0]));
-
-            return allOfFuture.thenApply(v -> matchAllOfFuture.stream()
-                    .map(CompletableFuture::join)
-                    .toList());
-        });
-
-        Summoner summoner = accountDtoFuture.thenCombine(
-                leagueEntryDtoFuture,
-                (accountDto, leagueEntryDtos) -> {
-                    Set<LeagueInfo> leagueInfos = leagueEntryDtos.stream()
-                            .map(dto -> LeagueInfo.builder()
-                                    .leagueId(dto.getLeagueId())
-                                    .queueType(dto.getQueueType())
-                                    .tier(dto.getTier())
-                                    .rank(dto.getRank())
-                                    .leaguePoints(dto.getLeaguePoints())
-                                    .wins(dto.getWins())
-                                    .losses(dto.getLosses())
-                                    .hotStreak(dto.isHotStreak())
-                                    .veteran(dto.isVeteran())
-                                    .freshBlood(dto.isFreshBlood())
-                                    .inactive(dto.isInactive())
-                                    .build())
-                            .collect(Collectors.toSet());
-                    return Summoner.create(
-                            accountDto.getPuuid(),
-                            accountDto.getGameName(),
-                            accountDto.getTagLine(),
-                            platform.getPlatformId(),
-                            summonerDto.getProfileIconId(),
-                            summonerDto.getSummonerLevel(),
-                            summonerDto.getRevisionDate(),
-                            leagueInfos
-                    );
-                }).join();
-
-        List<MatchDto> matchDtos = matchListFuture.join();
-
-        long middle = System.currentTimeMillis();
-        log.info("middle {} ms", middle - start);
-
-        summoner.resetClickDate();
-        saveSummonerDataUseCase.execute(summoner);
-        matchService.addAllMatch(matchDtos, new ArrayList<>());
-
-        redisLockHandler.deleteSummonerRenewal(puuid);
-        redisLockHandler.releaseLock(puuid);
-
-        long end = System.currentTimeMillis();
-        log.info("소요 시간: {}ms", end - start);
-        log.info("Lock 해제, 유저 전적 갱신 완료: {}", puuid);
     }
-
-
 }

--- a/infra/rabbitmq/src/main/java/com/mmrtr/lol/infra/rabbitmq/service/SummonerRenewalService.java
+++ b/infra/rabbitmq/src/main/java/com/mmrtr/lol/infra/rabbitmq/service/SummonerRenewalService.java
@@ -1,0 +1,165 @@
+package com.mmrtr.lol.infra.rabbitmq.service;
+
+import com.mmrtr.lol.common.type.Platform;
+import com.mmrtr.lol.domain.summoner.domain.Summoner;
+import com.mmrtr.lol.domain.summoner.domain.vo.LeagueInfo;
+import com.mmrtr.lol.domain.summoner.repository.SummonerRepositoryPort;
+import com.mmrtr.lol.domain.summoner.service.usecase.SaveSummonerDataUseCase;
+import com.mmrtr.lol.infra.persistence.match.entity.MatchEntity;
+import com.mmrtr.lol.infra.persistence.match.service.MatchService;
+import com.mmrtr.lol.infra.rabbitmq.dto.SummonerRenewalMessage;
+import com.mmrtr.lol.infra.riot.dto.account.AccountDto;
+import com.mmrtr.lol.infra.riot.dto.league.LeagueEntryDto;
+import com.mmrtr.lol.infra.riot.dto.match.MatchDto;
+import com.mmrtr.lol.infra.riot.dto.match_timeline.TimelineDto;
+import com.mmrtr.lol.infra.riot.dto.summoner.SummonerDto;
+import com.mmrtr.lol.infra.riot.service.RiotApiService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SummonerRenewalService {
+
+    private static final int MATCH_FETCH_COUNT = 20;
+
+    private final RabbitTemplate rabbitTemplate;
+    private final RiotApiService riotApiService;
+    private final MatchService matchService;
+    private final SummonerRepositoryPort summonerRepositoryPort;
+    private final SaveSummonerDataUseCase saveSummonerDataUseCase;
+    private final Executor requestExecutor;
+
+    public void renewSummoner(String puuid, Platform platform) {
+        long start = System.currentTimeMillis();
+        log.info("Lock 획득, 유저 전적 갱신 시작: {}", puuid);
+
+        CompletableFuture<SummonerDto> summonerDtoFuture = riotApiService.getSummonerByPuuid(puuid, platform, requestExecutor);
+        SummonerDto summonerDto = summonerDtoFuture.join();
+        if (summonerDto == null) {
+            log.error("RIOT API에서 소환사 정보를 조회할 수 없습니다. puuid: {}", puuid);
+            return;
+        }
+
+        Optional<Summoner> existingSummoner = summonerRepositoryPort.findByPuuid(puuid);
+        if (existingSummoner.isPresent()) {
+            LocalDateTime riotRevisionDate = LocalDateTime.ofInstant(
+                    Instant.ofEpochMilli(summonerDto.getRevisionDate()), ZoneId.systemDefault());
+            if (existingSummoner.get().getRevisionInfo().revisionDate().equals(riotRevisionDate)) {
+                log.info("revisionDate is same. No need to update.");
+                return;
+            }
+        }
+
+        long dbRevisionDateMillis = existingSummoner
+                .map(s -> s.getRevisionInfo().revisionDate()
+                        .atZone(ZoneId.systemDefault()).toInstant().toEpochMilli())
+                .orElse(0L);
+
+        CompletableFuture<AccountDto> accountDtoFuture = riotApiService
+                .getAccountByPuuid(puuid, platform, requestExecutor);
+        CompletableFuture<Set<LeagueEntryDto>> leagueEntryDtoFuture = riotApiService
+                .getLeagueEntriesByPuuid(puuid, platform, requestExecutor);
+        CompletableFuture<List<String>> matchIdListFuture = riotApiService.getMatchListByPuuid(
+                puuid, platform, dbRevisionDateMillis, 0, MATCH_FETCH_COUNT, requestExecutor);
+
+        CompletableFuture<List<String>> filteredMatchIdsFuture = matchIdListFuture.thenApply(matchIds -> {
+            if (matchIds.size() == MATCH_FETCH_COUNT) {
+                log.info("matchIds size is 20. send message for search more matchIds");
+                rabbitTemplate.convertAndSend(
+                        "renewal.topic.exchange",
+                        "renewal.match.find",
+                        new SummonerRenewalMessage(puuid, platform.getPlatformId(), dbRevisionDateMillis)
+                );
+            }
+
+            List<MatchEntity> matchList = matchService.findAllMatch(matchIds);
+            List<String> existMatchIds = matchList.stream().map(MatchEntity::getMatchId).toList();
+            return matchIds.stream().filter(matchId -> !existMatchIds.contains(matchId)).toList();
+        });
+
+        CompletableFuture<List<MatchDto>> matchListFuture = filteredMatchIdsFuture.thenCompose(filteredMatchIds -> {
+            List<CompletableFuture<MatchDto>> matchAllOfFuture = filteredMatchIds.stream()
+                    .map(matchId -> riotApiService.getMatchById(matchId, platform, requestExecutor))
+                    .toList();
+
+            CompletableFuture<Void> allOfFuture = CompletableFuture.allOf(matchAllOfFuture.toArray(new CompletableFuture[0]));
+
+            return allOfFuture.thenApply(v -> matchAllOfFuture.stream()
+                    .map(CompletableFuture::join)
+                    .toList());
+        });
+
+        CompletableFuture<List<TimelineDto>> timelineListFuture = filteredMatchIdsFuture.thenCompose(filteredMatchIds -> {
+            List<CompletableFuture<TimelineDto>> timelineAllOfFuture = filteredMatchIds.stream()
+                    .map(matchId -> riotApiService.getTimelineById(matchId, platform, requestExecutor))
+                    .toList();
+
+            CompletableFuture<Void> allOfFuture = CompletableFuture.allOf(timelineAllOfFuture.toArray(new CompletableFuture[0]));
+
+            return allOfFuture.thenApply(v -> timelineAllOfFuture.stream()
+                    .map(CompletableFuture::join)
+                    .toList());
+        });
+
+        Summoner summoner = accountDtoFuture.thenCombine(
+                leagueEntryDtoFuture,
+                (accountDto, leagueEntryDtos) -> {
+                    Set<LeagueInfo> leagueInfos = leagueEntryDtos.stream()
+                            .map(dto -> LeagueInfo.builder()
+                                    .leagueId(dto.getLeagueId())
+                                    .queueType(dto.getQueueType())
+                                    .tier(dto.getTier())
+                                    .rank(dto.getRank())
+                                    .leaguePoints(dto.getLeaguePoints())
+                                    .wins(dto.getWins())
+                                    .losses(dto.getLosses())
+                                    .hotStreak(dto.isHotStreak())
+                                    .veteran(dto.isVeteran())
+                                    .freshBlood(dto.isFreshBlood())
+                                    .inactive(dto.isInactive())
+                                    .build())
+                            .collect(Collectors.toSet());
+                    return Summoner.create(
+                            accountDto.getPuuid(),
+                            accountDto.getGameName(),
+                            accountDto.getTagLine(),
+                            platform.getPlatformId(),
+                            summonerDto.getProfileIconId(),
+                            summonerDto.getSummonerLevel(),
+                            summonerDto.getRevisionDate(),
+                            leagueInfos
+                    );
+                }).join();
+
+        List<MatchDto> matchDtos = matchListFuture.join();
+        List<TimelineDto> timelineDtos = timelineListFuture.join();
+
+        long middle = System.currentTimeMillis();
+        log.info("middle {} ms", middle - start);
+
+        summoner.resetClickDate();
+        saveSummonerDataUseCase.execute(summoner);
+
+        if (matchDtos != null && !matchDtos.isEmpty()) {
+            matchService.addAllMatch(matchDtos, timelineDtos);
+        }
+
+        long end = System.currentTimeMillis();
+        log.info("소요 시간: {}ms", end - start);
+        log.info("Lock 해제, 유저 전적 갱신 완료: {}", puuid);
+    }
+}


### PR DESCRIPTION
## Summary
- **TimeLineService**에 타임라인 이벤트 파싱 및 벌크 저장 로직 전체 구현, **TimeLineRepositoryImpl** 추가로 타임라인 데이터 벌크 INSERT 처리
- **MatchService** 매치 저장 로직을 개별 처리에서 일괄 수집 후 벌크 저장 방식으로 개선하여 DB 호출 횟수 감소
- **SummonerRenewalService** 분리로 리스너의 책임을 메시지 수신으로 한정하고, try-finally로 락 해제를 보장
- 타임라인 이벤트 엔티티 9개에 명시적 `@Column(name)` 추가, `date_version` → `data_version` 오타 수정
- DB 연결 정보를 환경변수로 변경, ddl-auto를 `update`로 변경, RabbitMQ concurrent consumers 10→20 증가

## Test plan
- [ ] 로컬 환경에서 docker-compose로 인프라 구동 확인
- [ ] 소환사 갱신 메시지 큐 처리 정상 동작 확인
- [ ] 매치 및 타임라인 데이터 벌크 저장 정상 동작 확인
- [ ] 동시 갱신 요청 시 락 획득/해제 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)