### PR TITLE
feat: 매치 저장 시 참가자 티어 정보 및 평균 티어 계산 저장

### DIFF
--- a/core/enum/src/main/java/com/mmrtr/lol/common/type/Queue.java
+++ b/core/enum/src/main/java/com/mmrtr/lol/common/type/Queue.java
@@ -1,8 +1,27 @@
 package com.mmrtr.lol.common.type;
 
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 public enum Queue {
-    RANKED_SOLO_5x5,
-    RANKED_FLEX_SR,
-    RANKED_FLEX_TT
-    ;
+    RANKED_SOLO_5x5(420),
+    RANKED_FLEX_SR(440),
+    RANKED_FLEX_TT(470);
+
+    private final int queueId;
+    private static final Map<Integer, Queue> BY_QUEUE_ID =
+            Stream.of(values()).collect(Collectors.toMap(q -> q.queueId, q -> q));
+
+    Queue(int queueId) {
+        this.queueId = queueId;
+    }
+
+    public int getQueueId() {
+        return queueId;
+    }
+
+    public static Queue fromQueueId(int queueId) {
+        return BY_QUEUE_ID.get(queueId);
+    }
 }

--- a/docs/ddl/07_match_tier_migration.sql
+++ b/docs/ddl/07_match_tier_migration.sql
@@ -1,0 +1,7 @@
+-- match_summoner: 개별 참가자 티어
+ALTER TABLE match_summoner ADD COLUMN tier VARCHAR(20);
+ALTER TABLE match_summoner ADD COLUMN tier_rank VARCHAR(5);
+ALTER TABLE match_summoner ADD COLUMN absolute_points INTEGER;
+
+-- match: 평균 티어
+ALTER TABLE match ADD COLUMN average_tier INTEGER;

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/league/repository/LeagueSummonerJpaRepository.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/league/repository/LeagueSummonerJpaRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -16,6 +17,8 @@ public interface LeagueSummonerJpaRepository extends JpaRepository<LeagueSummone
     Optional<LeagueSummonerEntity> findByPuuidAndLeagueId(String puuid, String leagueId);
 
     Optional<LeagueSummonerEntity> findAllByPuuidAndQueue(String puuid, String queue);
+
+    List<LeagueSummonerEntity> findAllByPuuidInAndQueue(Collection<String> puuids, String queue);
 
     @Query("""
             SELECT ls.puuid as puuid,

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/entity/MatchEntity.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/entity/MatchEntity.java
@@ -74,6 +74,9 @@ public class MatchEntity {
     @Comment("게임 시작 일시")
     private LocalDateTime gameStartDatetime;
 
+    @Comment("참가자 평균 절대 포인트")
+    private Integer averageTier;
+
     public MatchEntity(MatchDto matchDto, int season) {
         this.matchId = matchDto.getMetadata().getMatchId();
         this.dataVersion = matchDto.getMetadata().getDataVersion();
@@ -95,6 +98,10 @@ public class MatchEntity {
         this.gameCreateDatetime = LocalDateTime.ofInstant(Instant.ofEpochMilli(matchDto.getInfo().getGameCreation()), ZoneId.systemDefault());
         this.gameEndDatetime = LocalDateTime.ofInstant(Instant.ofEpochMilli(matchDto.getInfo().getGameEndTimestamp()), ZoneId.systemDefault());
         this.gameStartDatetime = LocalDateTime.ofInstant(Instant.ofEpochMilli(matchDto.getInfo().getGameStartTimestamp()), ZoneId.systemDefault());
+    }
+
+    public void setAverageTier(Integer averageTier) {
+        this.averageTier = averageTier;
     }
 
 }

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/entity/MatchSummonerEntity.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/entity/MatchSummonerEntity.java
@@ -326,6 +326,16 @@ public class MatchSummonerEntity {
     @Comment("시야 제거 핑 횟수")
     private int visionClearedPings;
 
+    @Comment("매치 저장 시점 소환사 티어")
+    private String tier;
+
+    @Comment("매치 저장 시점 소환사 디비전")
+    @Column(name = "tier_rank")
+    private String tierRank;
+
+    @Comment("매치 저장 시점 절대 포인트")
+    private Integer absolutePoints;
+
     @Embedded
     private ItemValue item;
 
@@ -335,7 +345,8 @@ public class MatchSummonerEntity {
     @Embedded
     private StyleValue styleValue;
 
-    public static MatchSummonerEntity of(MatchEntity match, ParticipantDto participantDto) {
+    public static MatchSummonerEntity of(MatchEntity match, ParticipantDto participantDto,
+                                          String tier, String tierRank, Integer absolutePoints) {
         return MatchSummonerEntity.builder()
                 .puuid(participantDto.getPuuid())
                 .matchId(match.getMatchId())
@@ -472,7 +483,9 @@ public class MatchSummonerEntity {
                 .totalAllyJungleMinionsKilled(participantDto.getTotalAllyJungleMinionsKilled())
                 .totalEnemyJungleMinionsKilled(participantDto.getTotalEnemyJungleMinionsKilled())
                 .visionClearedPings(participantDto.getVisionClearedPings())
-
+                .tier(tier)
+                .tierRank(tierRank)
+                .absolutePoints(absolutePoints)
                 .build();
     }
 }

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/repository/MatchRepositoryImpl.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/repository/MatchRepositoryImpl.java
@@ -69,7 +69,8 @@ public class MatchRepositoryImpl {
                 "season," +
                 "game_create_datetime," +
                 "game_end_datetime," +
-                "game_start_datetime" +
+                "game_start_datetime," +
+                "average_tier" +
                 ") VALUES (" +
                 ":matchId," +
                 ":dataVersion," +
@@ -90,7 +91,8 @@ public class MatchRepositoryImpl {
                 ":season," +
                 ":gameCreateDatetime," +
                 ":gameEndDatetime," +
-                ":gameStartDatetime "+
+                ":gameStartDatetime," +
+                ":averageTier" +
                 ") ON CONFLICT (match_id) DO NOTHING";
     }
 }

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/repository/MatchSummonerRepositoryImpl.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/repository/MatchSummonerRepositoryImpl.java
@@ -171,7 +171,10 @@ public class MatchSummonerRepositoryImpl {
                 "primary_rune_id," +
                 "primary_rune_ids," +
                 "secondary_rune_id," +
-                "secondary_rune_ids " +
+                "secondary_rune_ids," +
+                "tier," +
+                "tier_rank," +
+                "absolute_points " +
                 ") VALUES (" +
                 ":summonerId," +
                 ":matchId," +
@@ -318,7 +321,10 @@ public class MatchSummonerRepositoryImpl {
                 ":primaryRuneId," +
                 ":primaryRuneIds," +
                 ":secondaryRuneId," +
-                ":secondaryRuneIds" +
+                ":secondaryRuneIds," +
+                ":tier," +
+                ":tierRank," +
+                ":absolutePoints" +
                 ") ON CONFLICT (puuid, match_id) DO NOTHING";
 
         SqlParameterSource[] params = matchSummoners.stream()
@@ -470,6 +476,9 @@ public class MatchSummonerRepositoryImpl {
                             .addValue("primaryRuneIds", comment.getStyleValue().getPrimaryRuneIds())
                             .addValue("secondaryRuneId", comment.getStyleValue().getSecondaryRuneId())
                             .addValue("secondaryRuneIds", comment.getStyleValue().getSecondaryRuneIds())
+                            .addValue("tier", comment.getTier())
+                            .addValue("tierRank", comment.getTierRank())
+                            .addValue("absolutePoints", comment.getAbsolutePoints())
                             ;
                 })
                 .toArray(SqlParameterSource[]::new);

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/service/MatchService.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/service/MatchService.java
@@ -1,5 +1,8 @@
 package com.mmrtr.lol.infra.persistence.match.service;
 
+import com.mmrtr.lol.common.type.Queue;
+import com.mmrtr.lol.infra.persistence.league.entity.LeagueSummonerEntity;
+import com.mmrtr.lol.infra.persistence.league.repository.LeagueSummonerJpaRepository;
 import com.mmrtr.lol.infra.persistence.match.entity.ChallengesEntity;
 import com.mmrtr.lol.infra.persistence.match.entity.MatchEntity;
 import com.mmrtr.lol.infra.persistence.match.entity.MatchSummonerEntity;
@@ -18,8 +21,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -31,6 +35,7 @@ public class MatchService {
     private final ChallengesRepositoryImpl challengesRepository;
     private final MatchTeamRepositoryImpl matchTeamRepository;
     private final TimeLineService timeLineService;
+    private final LeagueSummonerJpaRepository leagueSummonerJpaRepository;
 
     @Transactional
     public void addAllMatch(List<MatchDto> matchDtos, List<TimelineDto> timelineDtos) {
@@ -38,7 +43,9 @@ public class MatchService {
         List<MatchEntity> matchEntities = matchDtos.stream()
                 .map(dto -> new MatchEntity(dto, 26))
                 .toList();
-        matchRepository.bulkSave(matchEntities);
+
+        // queueId별로 참가자 puuid를 수집하고 league 데이터를 배치 조회
+        Map<String, Map<String, LeagueSummonerEntity>> leagueByQueueAndPuuid = buildLeagueMap(matchDtos);
 
         List<MatchSummonerEntity> allMatchSummoners = new ArrayList<>();
         List<ChallengesEntity> allChallenges = new ArrayList<>();
@@ -48,10 +55,29 @@ public class MatchService {
             MatchDto matchDto = matchDtos.get(i);
             MatchEntity match = matchEntities.get(i);
 
+            Queue queue = Queue.fromQueueId(matchDto.getInfo().getQueueId());
+            Map<String, LeagueSummonerEntity> leagueMap = (queue != null)
+                    ? leagueByQueueAndPuuid.getOrDefault(queue.name(), Collections.emptyMap())
+                    : Collections.emptyMap();
+
             List<ParticipantDto> participants = matchDto.getInfo().getParticipants();
+            List<Integer> absolutePointsList = new ArrayList<>();
 
             for (ParticipantDto participant : participants) {
-                MatchSummonerEntity matchSummoner = MatchSummonerEntity.of(match, participant);
+                LeagueSummonerEntity league = leagueMap.get(participant.getPuuid());
+
+                String tier = null;
+                String tierRank = null;
+                Integer absolutePoints = null;
+
+                if (league != null) {
+                    tier = league.getTier();
+                    tierRank = league.getRank();
+                    absolutePoints = league.getAbsolutePoints();
+                    absolutePointsList.add(absolutePoints);
+                }
+
+                MatchSummonerEntity matchSummoner = MatchSummonerEntity.of(match, participant, tier, tierRank, absolutePoints);
                 ChallengesDto challengesDto = participant.getChallenges();
 
                 if (challengesDto == null) {
@@ -62,12 +88,22 @@ public class MatchService {
                 allChallenges.add(ChallengesEntity.of(matchSummoner, challengesDto));
             }
 
+            // 평균 티어 계산
+            if (!absolutePointsList.isEmpty()) {
+                int avgPoints = (int) absolutePointsList.stream()
+                        .mapToInt(Integer::intValue)
+                        .average()
+                        .orElse(0);
+                match.setAverageTier(avgPoints);
+            }
+
             List<TeamDto> teams = matchDto.getInfo().getTeams();
             for (TeamDto team : teams) {
                 allMatchTeams.add(MatchTeamEntity.of(match, team));
             }
         }
 
+        matchRepository.bulkSave(matchEntities);
         matchSummonerRepository.bulkSave(allMatchSummoners);
         challengesRepository.bulkSave(allChallenges);
         matchTeamRepository.bulkSave(allMatchTeams);
@@ -75,6 +111,41 @@ public class MatchService {
         if (timelineDtos != null && !timelineDtos.isEmpty()) {
             timeLineService.saveAll(matchEntities, timelineDtos);
         }
+    }
+
+    private Map<String, Map<String, LeagueSummonerEntity>> buildLeagueMap(List<MatchDto> matchDtos) {
+        // queueName -> Set<puuid> 수집
+        Map<String, Set<String>> puuidsByQueue = new HashMap<>();
+
+        for (MatchDto matchDto : matchDtos) {
+            Queue queue = Queue.fromQueueId(matchDto.getInfo().getQueueId());
+            if (queue == null) {
+                continue;
+            }
+
+            Set<String> puuids = puuidsByQueue.computeIfAbsent(queue.name(), k -> new HashSet<>());
+            for (ParticipantDto participant : matchDto.getInfo().getParticipants()) {
+                puuids.add(participant.getPuuid());
+            }
+        }
+
+        // queueName -> (puuid -> LeagueSummonerEntity) 맵 구성
+        Map<String, Map<String, LeagueSummonerEntity>> result = new HashMap<>();
+
+        for (Map.Entry<String, Set<String>> entry : puuidsByQueue.entrySet()) {
+            String queueName = entry.getKey();
+            Set<String> puuids = entry.getValue();
+
+            List<LeagueSummonerEntity> leagueEntities =
+                    leagueSummonerJpaRepository.findAllByPuuidInAndQueue(puuids, queueName);
+
+            Map<String, LeagueSummonerEntity> byPuuid = leagueEntities.stream()
+                    .collect(Collectors.toMap(LeagueSummonerEntity::getPuuid, Function.identity()));
+
+            result.put(queueName, byPuuid);
+        }
+
+        return result;
     }
 
     public List<MatchEntity> findAllMatch(List<String> matchIds) {


### PR DESCRIPTION
## Summary
- 매치 저장 시 `league_summoner` 테이블에서 참가자의 현재 티어를 조회하여 `match_summoner`에 개별 tier/rank/absolutePoints 저장
- 각 매치의 전체 참가자 평균 absolutePoints를 계산하여 `match.average_tier`에 저장
- `Queue` enum에 `queueId` 필드 및 `fromQueueId()` 추가로 랭크/비랭크 큐 구분, 비랭크 큐는 티어 조회 스킵

## 변경 파일
| 파일 | 설명 |
|------|------|
| `docs/ddl/07_match_tier_migration.sql` | DDL 마이그레이션 (match_summoner에 tier/tier_rank/absolute_points, match에 average_tier) |
| `Queue.java` | queueId 매핑 및 fromQueueId() 추가 |
| `LeagueSummonerJpaRepository.java` | findAllByPuuidInAndQueue() 배치 조회 추가 |
| `MatchEntity.java` | averageTier 필드 및 setter 추가 |
| `MatchSummonerEntity.java` | tier/tierRank/absolutePoints 필드 추가, of() 시그니처 변경 |
| `MatchRepositoryImpl.java` | insertSql에 average_tier 컬럼 추가 |
| `MatchSummonerRepositoryImpl.java` | bulkSave SQL에 tier/tier_rank/absolute_points 컬럼 추가 |
| `MatchService.java` | 핵심 로직: league 배치 조회 → 티어 매핑 → 평균 계산 |

## Test plan
- [ ] DDL을 로컬 PostgreSQL에 실행하여 스키마 변경 확인
- [ ] 랭크 큐 매치 저장 시 match_summoner에 tier 데이터 저장 확인
- [ ] 랭크 큐 매치 저장 시 match에 averageTier 계산 확인
- [ ] 비랭크 큐 매치 저장 시 모든 티어 필드 null 확인
- [ ] league_summoner에 없는 참가자의 tier 필드 null, 평균 계산에서 제외 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)