### PR TITLE
feat: 챔피언 통계 API 및 Flyway 마이그레이션 도입

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lol-db-schema"]
+	path = lol-db-schema
+	url = https://github.com/padosol/lol-db-schema.git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ LOL Repository는 League of Legends 데이터 처리를 위한 컨슈머 서비�
 - PostgreSQL (JPA/Hibernate)
 - Redis + Redisson 3.46.0 (캐싱, 분산 락)
 - RabbitMQ (비동기 메시지 처리)
+- Flyway (DB 마이그레이션)
 
 ## 3. 프로젝트 구조
 
@@ -20,6 +21,7 @@ LOL Repository는 League of Legends 데이터 처리를 위한 컨슈머 서비�
 ```
 lol-repository (루트)
 ├── app                    # Spring Boot 애플리케이션 진입점 (LolRepositoryApplication.java)
+├── lol-db-schema/         # Git 서브모듈 (padosol/lol-db-schema) - Flyway 마이그레이션 SQL
 ├── core/
 │   ├── domain             # DDD 도메인 비즈니스 로직 (Port 인터페이스, UseCase, Service)
 │   └── enum               # 공유 enum 타입들 (Region, Platform 등)
@@ -53,6 +55,12 @@ com.mmrtr.lol.domain/
 ## 4. 명령어
 
 ```bash
+# 서브모듈 초기화 (최초 클론 후)
+git submodule update --init --recursive
+
+# 서브모듈 최신화
+git submodule update --remote lol-db-schema
+
 # 전체 모듈 빌드
 ./gradlew build
 

--- a/core/domain/src/main/java/com/mmrtr/lol/domain/champion_stat/domain/ChampionItemStat.java
+++ b/core/domain/src/main/java/com/mmrtr/lol/domain/champion_stat/domain/ChampionItemStat.java
@@ -1,0 +1,23 @@
+package com.mmrtr.lol.domain.champion_stat.domain;
+
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ChampionItemStat {
+
+    private Long id;
+    private int championId;
+    private String teamPosition;
+    private int season;
+    private String tierGroup;
+    private String platformId;
+    private int queueId;
+    private String gameVersion;
+    private String buildType;
+    private String itemIds;
+    private long games;
+    private long wins;
+}

--- a/core/domain/src/main/java/com/mmrtr/lol/domain/champion_stat/domain/ChampionMatchupStat.java
+++ b/core/domain/src/main/java/com/mmrtr/lol/domain/champion_stat/domain/ChampionMatchupStat.java
@@ -1,0 +1,28 @@
+package com.mmrtr.lol.domain.champion_stat.domain;
+
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ChampionMatchupStat {
+
+    private Long id;
+    private int championId;
+    private String teamPosition;
+    private int season;
+    private String tierGroup;
+    private String platformId;
+    private int queueId;
+    private String gameVersion;
+    private int opponentChampionId;
+    private long games;
+    private long wins;
+    private BigDecimal avgKills;
+    private BigDecimal avgDeaths;
+    private BigDecimal avgAssists;
+    private BigDecimal avgGoldDiff;
+}

--- a/core/domain/src/main/java/com/mmrtr/lol/domain/champion_stat/domain/ChampionRuneStat.java
+++ b/core/domain/src/main/java/com/mmrtr/lol/domain/champion_stat/domain/ChampionRuneStat.java
@@ -1,0 +1,28 @@
+package com.mmrtr.lol.domain.champion_stat.domain;
+
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ChampionRuneStat {
+
+    private Long id;
+    private int championId;
+    private String teamPosition;
+    private int season;
+    private String tierGroup;
+    private String platformId;
+    private int queueId;
+    private String gameVersion;
+    private int primaryRuneId;
+    private String primaryRuneIds;
+    private int secondaryRuneId;
+    private String secondaryRuneIds;
+    private int statOffense;
+    private int statFlex;
+    private int statDefense;
+    private long games;
+    private long wins;
+}

--- a/core/domain/src/main/java/com/mmrtr/lol/domain/champion_stat/domain/ChampionSkillStat.java
+++ b/core/domain/src/main/java/com/mmrtr/lol/domain/champion_stat/domain/ChampionSkillStat.java
@@ -1,0 +1,23 @@
+package com.mmrtr.lol.domain.champion_stat.domain;
+
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ChampionSkillStat {
+
+    private Long id;
+    private int championId;
+    private String teamPosition;
+    private int season;
+    private String tierGroup;
+    private String platformId;
+    private int queueId;
+    private String gameVersion;
+    private String skillOrder;
+    private String skillPriority;
+    private long games;
+    private long wins;
+}

--- a/core/domain/src/main/java/com/mmrtr/lol/domain/champion_stat/domain/ChampionSpellStat.java
+++ b/core/domain/src/main/java/com/mmrtr/lol/domain/champion_stat/domain/ChampionSpellStat.java
@@ -1,0 +1,23 @@
+package com.mmrtr.lol.domain.champion_stat.domain;
+
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ChampionSpellStat {
+
+    private Long id;
+    private int championId;
+    private String teamPosition;
+    private int season;
+    private String tierGroup;
+    private String platformId;
+    private int queueId;
+    private String gameVersion;
+    private int spell1Id;
+    private int spell2Id;
+    private long games;
+    private long wins;
+}

--- a/core/domain/src/main/java/com/mmrtr/lol/domain/champion_stat/domain/ChampionStatSummary.java
+++ b/core/domain/src/main/java/com/mmrtr/lol/domain/champion_stat/domain/ChampionStatSummary.java
@@ -1,0 +1,30 @@
+package com.mmrtr.lol.domain.champion_stat.domain;
+
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ChampionStatSummary {
+
+    private Long id;
+    private int championId;
+    private String teamPosition;
+    private int season;
+    private String tierGroup;
+    private String platformId;
+    private int queueId;
+    private String gameVersion;
+    private long totalGames;
+    private long wins;
+    private long totalBans;
+    private long totalMatchesInDimension;
+    private BigDecimal avgKills;
+    private BigDecimal avgDeaths;
+    private BigDecimal avgAssists;
+    private BigDecimal avgCs;
+    private BigDecimal avgGold;
+}

--- a/core/domain/src/main/java/com/mmrtr/lol/domain/champion_stat/domain/ItemMetadata.java
+++ b/core/domain/src/main/java/com/mmrtr/lol/domain/champion_stat/domain/ItemMetadata.java
@@ -1,0 +1,15 @@
+package com.mmrtr.lol.domain.champion_stat.domain;
+
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ItemMetadata {
+
+    private int itemId;
+    private String itemName;
+    private String itemCategory;
+    private String gameVersion;
+}

--- a/core/domain/src/main/java/com/mmrtr/lol/domain/champion_stat/repository/ChampionStatRepositoryPort.java
+++ b/core/domain/src/main/java/com/mmrtr/lol/domain/champion_stat/repository/ChampionStatRepositoryPort.java
@@ -1,0 +1,27 @@
+package com.mmrtr.lol.domain.champion_stat.repository;
+
+import com.mmrtr.lol.domain.champion_stat.domain.*;
+
+import java.util.List;
+
+public interface ChampionStatRepositoryPort {
+
+    // 삭제
+    void deleteAllBySeasonAndQueueId(int season, int queueId);
+
+    // 벌크 저장
+    void bulkSaveSummaries(List<ChampionStatSummary> summaries);
+    void bulkSaveRuneStats(List<ChampionRuneStat> runeStats);
+    void bulkSaveSpellStats(List<ChampionSpellStat> spellStats);
+    void bulkSaveSkillStats(List<ChampionSkillStat> skillStats);
+    void bulkSaveItemStats(List<ChampionItemStat> itemStats);
+    void bulkSaveMatchupStats(List<ChampionMatchupStat> matchupStats);
+
+    // 조회
+    List<ChampionStatSummary> findSummaries(int championId, String teamPosition, int season, String tierGroup, String platformId, int queueId, String gameVersion);
+    List<ChampionRuneStat> findRuneStats(int championId, String teamPosition, int season, String tierGroup, String platformId, int queueId, String gameVersion);
+    List<ChampionSpellStat> findSpellStats(int championId, String teamPosition, int season, String tierGroup, String platformId, int queueId, String gameVersion);
+    List<ChampionSkillStat> findSkillStats(int championId, String teamPosition, int season, String tierGroup, String platformId, int queueId, String gameVersion);
+    List<ChampionItemStat> findItemStats(int championId, String teamPosition, int season, String tierGroup, String platformId, int queueId, String gameVersion);
+    List<ChampionMatchupStat> findMatchupStats(int championId, String teamPosition, int season, String tierGroup, String platformId, int queueId, String gameVersion);
+}

--- a/core/domain/src/main/java/com/mmrtr/lol/domain/champion_stat/service/usecase/ChampionStatQueryUseCase.java
+++ b/core/domain/src/main/java/com/mmrtr/lol/domain/champion_stat/service/usecase/ChampionStatQueryUseCase.java
@@ -1,0 +1,15 @@
+package com.mmrtr.lol.domain.champion_stat.service.usecase;
+
+import com.mmrtr.lol.domain.champion_stat.domain.*;
+
+import java.util.List;
+
+public interface ChampionStatQueryUseCase {
+
+    List<ChampionStatSummary> getSummaries(int championId, String position, int season, String tierGroup, String platformId, int queueId, String patch);
+    List<ChampionRuneStat> getRuneStats(int championId, String position, int season, String tierGroup, String platformId, int queueId, String patch);
+    List<ChampionSpellStat> getSpellStats(int championId, String position, int season, String tierGroup, String platformId, int queueId, String patch);
+    List<ChampionSkillStat> getSkillStats(int championId, String position, int season, String tierGroup, String platformId, int queueId, String patch);
+    List<ChampionItemStat> getItemStats(int championId, String position, int season, String tierGroup, String platformId, int queueId, String patch);
+    List<ChampionMatchupStat> getMatchupStats(int championId, String position, int season, String tierGroup, String platformId, int queueId, String patch);
+}

--- a/core/domain/src/main/java/com/mmrtr/lol/domain/champion_stat/service/usecase/ItemMetadataUseCase.java
+++ b/core/domain/src/main/java/com/mmrtr/lol/domain/champion_stat/service/usecase/ItemMetadataUseCase.java
@@ -1,0 +1,14 @@
+package com.mmrtr.lol.domain.champion_stat.service.usecase;
+
+import com.mmrtr.lol.domain.champion_stat.domain.ItemMetadata;
+
+import java.util.List;
+
+public interface ItemMetadataUseCase {
+
+    ItemMetadata save(ItemMetadata itemMetadata);
+
+    List<ItemMetadata> saveAll(List<ItemMetadata> metadataList);
+
+    List<ItemMetadata> findAll();
+}

--- a/core/domain/src/main/java/com/mmrtr/lol/domain/champion_stat/service/usecase/TriggerChampionStatAggregationUseCase.java
+++ b/core/domain/src/main/java/com/mmrtr/lol/domain/champion_stat/service/usecase/TriggerChampionStatAggregationUseCase.java
@@ -1,0 +1,6 @@
+package com.mmrtr.lol.domain.champion_stat.service.usecase;
+
+public interface TriggerChampionStatAggregationUseCase {
+
+    void execute(int season, int queueId);
+}

--- a/core/enum/src/main/java/com/mmrtr/lol/common/type/BuildType.java
+++ b/core/enum/src/main/java/com/mmrtr/lol/common/type/BuildType.java
@@ -1,0 +1,7 @@
+package com.mmrtr.lol.common.type;
+
+public enum BuildType {
+    STARTER,
+    BOOTS,
+    CORE
+}

--- a/core/enum/src/main/java/com/mmrtr/lol/common/type/ItemCategory.java
+++ b/core/enum/src/main/java/com/mmrtr/lol/common/type/ItemCategory.java
@@ -1,0 +1,9 @@
+package com.mmrtr.lol.common.type;
+
+public enum ItemCategory {
+    STARTER,
+    BOOTS,
+    LEGENDARY,
+    CONSUMABLE,
+    TRINKET
+}

--- a/core/enum/src/main/java/com/mmrtr/lol/common/type/Position.java
+++ b/core/enum/src/main/java/com/mmrtr/lol/common/type/Position.java
@@ -1,0 +1,10 @@
+package com.mmrtr.lol.common.type;
+
+public enum Position {
+
+    TOP,
+    JUNGLE,
+    MIDDLE,
+    BOTTOM,
+    UTILITY
+}

--- a/core/enum/src/main/java/com/mmrtr/lol/common/type/TierGroup.java
+++ b/core/enum/src/main/java/com/mmrtr/lol/common/type/TierGroup.java
@@ -1,0 +1,20 @@
+package com.mmrtr.lol.common.type;
+
+import lombok.Getter;
+
+import java.util.Set;
+
+@Getter
+public enum TierGroup {
+
+    ALL(Set.of("CHALLENGER", "GRANDMASTER", "MASTER", "DIAMOND", "EMERALD", "PLATINUM", "GOLD", "SILVER", "BRONZE", "IRON")),
+    EMERALD_PLUS(Set.of("CHALLENGER", "GRANDMASTER", "MASTER", "DIAMOND", "EMERALD")),
+    DIAMOND_PLUS(Set.of("CHALLENGER", "GRANDMASTER", "MASTER", "DIAMOND")),
+    MASTER_PLUS(Set.of("CHALLENGER", "GRANDMASTER", "MASTER"));
+
+    private final Set<String> includedTiers;
+
+    TierGroup(Set<String> includedTiers) {
+        this.includedTiers = includedTiers;
+    }
+}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,6 +12,17 @@ services:
       POSTGRES_DB: postgresCLAUDE
     volumes:
       - ./postgres-data:/var/lib/postgresql
+  # 2. 통계를 처리할 분석 DB (ClickHouse)
+  clickhouse_analytics:
+    image: clickhouse/clickhouse-server:latest
+    container_name: clickhouse_analytics
+    ports:
+      - "8123:8123" # HTTP 인터페이스
+      - "9000:9000" # 기본 클라이언트 포트
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
 
   rabbitmq:
     image: rabbitmq:3.13-management

--- a/infra/api/src/main/java/com/mmrtr/lol/controller/admin/ChampionStatAdminController.java
+++ b/infra/api/src/main/java/com/mmrtr/lol/controller/admin/ChampionStatAdminController.java
@@ -1,0 +1,58 @@
+package com.mmrtr.lol.controller.admin;
+
+import com.mmrtr.lol.controller.admin.request.ItemMetadataRequest;
+import com.mmrtr.lol.controller.admin.response.ChampionStatAggregateResponse;
+import com.mmrtr.lol.domain.champion_stat.domain.ItemMetadata;
+import com.mmrtr.lol.domain.champion_stat.service.usecase.ItemMetadataUseCase;
+import com.mmrtr.lol.domain.champion_stat.service.usecase.TriggerChampionStatAggregationUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/admin/champion-stats")
+@RequiredArgsConstructor
+public class ChampionStatAdminController {
+
+    private final TriggerChampionStatAggregationUseCase triggerChampionStatAggregationUseCase;
+    private final ItemMetadataUseCase itemMetadataUseCase;
+
+    @PostMapping("/aggregate")
+    public ResponseEntity<ChampionStatAggregateResponse> aggregate(
+            @RequestParam int season,
+            @RequestParam int queueId) {
+        triggerChampionStatAggregationUseCase.execute(season, queueId);
+        return ResponseEntity.ok(ChampionStatAggregateResponse.of());
+    }
+
+    @PostMapping("/item-metadata")
+    public ResponseEntity<ItemMetadata> saveItemMetadata(@RequestBody ItemMetadataRequest request) {
+        ItemMetadata itemMetadata = ItemMetadata.builder()
+                .itemId(request.itemId())
+                .itemName(request.itemName())
+                .itemCategory(request.itemCategory())
+                .gameVersion(request.gameVersion())
+                .build();
+        return ResponseEntity.ok(itemMetadataUseCase.save(itemMetadata));
+    }
+
+    @PostMapping("/item-metadata/bulk")
+    public ResponseEntity<List<ItemMetadata>> saveItemMetadataBulk(@RequestBody List<ItemMetadataRequest> requests) {
+        List<ItemMetadata> metadataList = requests.stream()
+                .map(req -> ItemMetadata.builder()
+                        .itemId(req.itemId())
+                        .itemName(req.itemName())
+                        .itemCategory(req.itemCategory())
+                        .gameVersion(req.gameVersion())
+                        .build())
+                .toList();
+        return ResponseEntity.ok(itemMetadataUseCase.saveAll(metadataList));
+    }
+
+    @GetMapping("/item-metadata")
+    public ResponseEntity<List<ItemMetadata>> getItemMetadata() {
+        return ResponseEntity.ok(itemMetadataUseCase.findAll());
+    }
+}

--- a/infra/api/src/main/java/com/mmrtr/lol/controller/admin/ChampionStatAdminController.java
+++ b/infra/api/src/main/java/com/mmrtr/lol/controller/admin/ChampionStatAdminController.java
@@ -32,7 +32,7 @@ public class ChampionStatAdminController {
         ItemMetadata itemMetadata = ItemMetadata.builder()
                 .itemId(request.itemId())
                 .itemName(request.itemName())
-                .itemCategory(request.itemCategory())
+                .itemCategory(request.itemCategory().name())
                 .gameVersion(request.gameVersion())
                 .build();
         return ResponseEntity.ok(itemMetadataUseCase.save(itemMetadata));
@@ -44,7 +44,7 @@ public class ChampionStatAdminController {
                 .map(req -> ItemMetadata.builder()
                         .itemId(req.itemId())
                         .itemName(req.itemName())
-                        .itemCategory(req.itemCategory())
+                        .itemCategory(req.itemCategory().name())
                         .gameVersion(req.gameVersion())
                         .build())
                 .toList();

--- a/infra/api/src/main/java/com/mmrtr/lol/controller/admin/request/ItemMetadataRequest.java
+++ b/infra/api/src/main/java/com/mmrtr/lol/controller/admin/request/ItemMetadataRequest.java
@@ -1,9 +1,11 @@
 package com.mmrtr.lol.controller.admin.request;
 
+import com.mmrtr.lol.common.type.ItemCategory;
+
 public record ItemMetadataRequest(
         int itemId,
         String itemName,
-        String itemCategory,
+        ItemCategory itemCategory,
         String gameVersion
 ) {
 }

--- a/infra/api/src/main/java/com/mmrtr/lol/controller/admin/request/ItemMetadataRequest.java
+++ b/infra/api/src/main/java/com/mmrtr/lol/controller/admin/request/ItemMetadataRequest.java
@@ -1,0 +1,9 @@
+package com.mmrtr.lol.controller.admin.request;
+
+public record ItemMetadataRequest(
+        int itemId,
+        String itemName,
+        String itemCategory,
+        String gameVersion
+) {
+}

--- a/infra/api/src/main/java/com/mmrtr/lol/controller/admin/response/ChampionStatAggregateResponse.java
+++ b/infra/api/src/main/java/com/mmrtr/lol/controller/admin/response/ChampionStatAggregateResponse.java
@@ -1,0 +1,17 @@
+package com.mmrtr.lol.controller.admin.response;
+
+import java.time.LocalDateTime;
+
+public record ChampionStatAggregateResponse(
+        boolean success,
+        String message,
+        LocalDateTime executedAt
+) {
+    public static ChampionStatAggregateResponse of() {
+        return new ChampionStatAggregateResponse(
+                true,
+                "챔피언 통계 집계가 완료되었습니다.",
+                LocalDateTime.now()
+        );
+    }
+}

--- a/infra/api/src/main/java/com/mmrtr/lol/controller/champion/ChampionStatController.java
+++ b/infra/api/src/main/java/com/mmrtr/lol/controller/champion/ChampionStatController.java
@@ -1,0 +1,97 @@
+package com.mmrtr.lol.controller.champion;
+
+import com.mmrtr.lol.common.type.Position;
+import com.mmrtr.lol.common.type.TierGroup;
+import com.mmrtr.lol.controller.champion.response.*;
+import com.mmrtr.lol.domain.champion_stat.service.usecase.ChampionStatQueryUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/riot/champions/{championId}/stats")
+@RequiredArgsConstructor
+public class ChampionStatController {
+
+    private final ChampionStatQueryUseCase championStatQueryUseCase;
+
+    @GetMapping("/summary")
+    public ResponseEntity<List<ChampionStatSummaryResponse>> getSummary(
+            @PathVariable int championId,
+            @RequestParam Position position,
+            @RequestParam int season,
+            @RequestParam TierGroup tierGroup,
+            @RequestParam String platform,
+            @RequestParam int queueId,
+            @RequestParam String patch) {
+        return ResponseEntity.ok(championStatQueryUseCase.getSummaries(championId, position.name(), season, tierGroup.name(), platform, queueId, patch)
+                .stream().map(ChampionStatSummaryResponse::of).toList());
+    }
+
+    @GetMapping("/runes")
+    public ResponseEntity<List<ChampionRuneStatResponse>> getRuneStats(
+            @PathVariable int championId,
+            @RequestParam Position position,
+            @RequestParam int season,
+            @RequestParam TierGroup tierGroup,
+            @RequestParam String platform,
+            @RequestParam int queueId,
+            @RequestParam String patch) {
+        return ResponseEntity.ok(championStatQueryUseCase.getRuneStats(championId, position.name(), season, tierGroup.name(), platform, queueId, patch)
+                .stream().map(ChampionRuneStatResponse::of).toList());
+    }
+
+    @GetMapping("/spells")
+    public ResponseEntity<List<ChampionSpellStatResponse>> getSpellStats(
+            @PathVariable int championId,
+            @RequestParam Position position,
+            @RequestParam int season,
+            @RequestParam TierGroup tierGroup,
+            @RequestParam String platform,
+            @RequestParam int queueId,
+            @RequestParam String patch) {
+        return ResponseEntity.ok(championStatQueryUseCase.getSpellStats(championId, position.name(), season, tierGroup.name(), platform, queueId, patch)
+                .stream().map(ChampionSpellStatResponse::of).toList());
+    }
+
+    @GetMapping("/skills")
+    public ResponseEntity<List<ChampionSkillStatResponse>> getSkillStats(
+            @PathVariable int championId,
+            @RequestParam Position position,
+            @RequestParam int season,
+            @RequestParam TierGroup tierGroup,
+            @RequestParam String platform,
+            @RequestParam int queueId,
+            @RequestParam String patch) {
+        return ResponseEntity.ok(championStatQueryUseCase.getSkillStats(championId, position.name(), season, tierGroup.name(), platform, queueId, patch)
+                .stream().map(ChampionSkillStatResponse::of).toList());
+    }
+
+    @GetMapping("/items")
+    public ResponseEntity<List<ChampionItemStatResponse>> getItemStats(
+            @PathVariable int championId,
+            @RequestParam Position position,
+            @RequestParam int season,
+            @RequestParam TierGroup tierGroup,
+            @RequestParam String platform,
+            @RequestParam int queueId,
+            @RequestParam String patch) {
+        return ResponseEntity.ok(championStatQueryUseCase.getItemStats(championId, position.name(), season, tierGroup.name(), platform, queueId, patch)
+                .stream().map(ChampionItemStatResponse::of).toList());
+    }
+
+    @GetMapping("/matchups")
+    public ResponseEntity<List<ChampionMatchupStatResponse>> getMatchupStats(
+            @PathVariable int championId,
+            @RequestParam Position position,
+            @RequestParam int season,
+            @RequestParam TierGroup tierGroup,
+            @RequestParam String platform,
+            @RequestParam int queueId,
+            @RequestParam String patch) {
+        return ResponseEntity.ok(championStatQueryUseCase.getMatchupStats(championId, position.name(), season, tierGroup.name(), platform, queueId, patch)
+                .stream().map(ChampionMatchupStatResponse::of).toList());
+    }
+}

--- a/infra/api/src/main/java/com/mmrtr/lol/controller/champion/response/ChampionItemStatResponse.java
+++ b/infra/api/src/main/java/com/mmrtr/lol/controller/champion/response/ChampionItemStatResponse.java
@@ -1,0 +1,23 @@
+package com.mmrtr.lol.controller.champion.response;
+
+import com.mmrtr.lol.domain.champion_stat.domain.ChampionItemStat;
+
+public record ChampionItemStatResponse(
+        int championId,
+        String teamPosition,
+        String buildType,
+        String itemIds,
+        long games,
+        long wins
+) {
+    public static ChampionItemStatResponse of(ChampionItemStat domain) {
+        return new ChampionItemStatResponse(
+                domain.getChampionId(),
+                domain.getTeamPosition(),
+                domain.getBuildType(),
+                domain.getItemIds(),
+                domain.getGames(),
+                domain.getWins()
+        );
+    }
+}

--- a/infra/api/src/main/java/com/mmrtr/lol/controller/champion/response/ChampionMatchupStatResponse.java
+++ b/infra/api/src/main/java/com/mmrtr/lol/controller/champion/response/ChampionMatchupStatResponse.java
@@ -1,0 +1,31 @@
+package com.mmrtr.lol.controller.champion.response;
+
+import com.mmrtr.lol.domain.champion_stat.domain.ChampionMatchupStat;
+
+import java.math.BigDecimal;
+
+public record ChampionMatchupStatResponse(
+        int championId,
+        String teamPosition,
+        int opponentChampionId,
+        long games,
+        long wins,
+        BigDecimal avgKills,
+        BigDecimal avgDeaths,
+        BigDecimal avgAssists,
+        BigDecimal avgGoldDiff
+) {
+    public static ChampionMatchupStatResponse of(ChampionMatchupStat domain) {
+        return new ChampionMatchupStatResponse(
+                domain.getChampionId(),
+                domain.getTeamPosition(),
+                domain.getOpponentChampionId(),
+                domain.getGames(),
+                domain.getWins(),
+                domain.getAvgKills(),
+                domain.getAvgDeaths(),
+                domain.getAvgAssists(),
+                domain.getAvgGoldDiff()
+        );
+    }
+}

--- a/infra/api/src/main/java/com/mmrtr/lol/controller/champion/response/ChampionRuneStatResponse.java
+++ b/infra/api/src/main/java/com/mmrtr/lol/controller/champion/response/ChampionRuneStatResponse.java
@@ -1,0 +1,33 @@
+package com.mmrtr.lol.controller.champion.response;
+
+import com.mmrtr.lol.domain.champion_stat.domain.ChampionRuneStat;
+
+public record ChampionRuneStatResponse(
+        int championId,
+        String teamPosition,
+        int primaryRuneId,
+        String primaryRuneIds,
+        int secondaryRuneId,
+        String secondaryRuneIds,
+        int statOffense,
+        int statFlex,
+        int statDefense,
+        long games,
+        long wins
+) {
+    public static ChampionRuneStatResponse of(ChampionRuneStat domain) {
+        return new ChampionRuneStatResponse(
+                domain.getChampionId(),
+                domain.getTeamPosition(),
+                domain.getPrimaryRuneId(),
+                domain.getPrimaryRuneIds(),
+                domain.getSecondaryRuneId(),
+                domain.getSecondaryRuneIds(),
+                domain.getStatOffense(),
+                domain.getStatFlex(),
+                domain.getStatDefense(),
+                domain.getGames(),
+                domain.getWins()
+        );
+    }
+}

--- a/infra/api/src/main/java/com/mmrtr/lol/controller/champion/response/ChampionSkillStatResponse.java
+++ b/infra/api/src/main/java/com/mmrtr/lol/controller/champion/response/ChampionSkillStatResponse.java
@@ -1,0 +1,23 @@
+package com.mmrtr.lol.controller.champion.response;
+
+import com.mmrtr.lol.domain.champion_stat.domain.ChampionSkillStat;
+
+public record ChampionSkillStatResponse(
+        int championId,
+        String teamPosition,
+        String skillOrder,
+        String skillPriority,
+        long games,
+        long wins
+) {
+    public static ChampionSkillStatResponse of(ChampionSkillStat domain) {
+        return new ChampionSkillStatResponse(
+                domain.getChampionId(),
+                domain.getTeamPosition(),
+                domain.getSkillOrder(),
+                domain.getSkillPriority(),
+                domain.getGames(),
+                domain.getWins()
+        );
+    }
+}

--- a/infra/api/src/main/java/com/mmrtr/lol/controller/champion/response/ChampionSpellStatResponse.java
+++ b/infra/api/src/main/java/com/mmrtr/lol/controller/champion/response/ChampionSpellStatResponse.java
@@ -1,0 +1,23 @@
+package com.mmrtr.lol.controller.champion.response;
+
+import com.mmrtr.lol.domain.champion_stat.domain.ChampionSpellStat;
+
+public record ChampionSpellStatResponse(
+        int championId,
+        String teamPosition,
+        int spell1Id,
+        int spell2Id,
+        long games,
+        long wins
+) {
+    public static ChampionSpellStatResponse of(ChampionSpellStat domain) {
+        return new ChampionSpellStatResponse(
+                domain.getChampionId(),
+                domain.getTeamPosition(),
+                domain.getSpell1Id(),
+                domain.getSpell2Id(),
+                domain.getGames(),
+                domain.getWins()
+        );
+    }
+}

--- a/infra/api/src/main/java/com/mmrtr/lol/controller/champion/response/ChampionStatSummaryResponse.java
+++ b/infra/api/src/main/java/com/mmrtr/lol/controller/champion/response/ChampionStatSummaryResponse.java
@@ -1,0 +1,35 @@
+package com.mmrtr.lol.controller.champion.response;
+
+import com.mmrtr.lol.domain.champion_stat.domain.ChampionStatSummary;
+
+import java.math.BigDecimal;
+
+public record ChampionStatSummaryResponse(
+        int championId,
+        String teamPosition,
+        long totalGames,
+        long wins,
+        long totalBans,
+        long totalMatchesInDimension,
+        BigDecimal avgKills,
+        BigDecimal avgDeaths,
+        BigDecimal avgAssists,
+        BigDecimal avgCs,
+        BigDecimal avgGold
+) {
+    public static ChampionStatSummaryResponse of(ChampionStatSummary domain) {
+        return new ChampionStatSummaryResponse(
+                domain.getChampionId(),
+                domain.getTeamPosition(),
+                domain.getTotalGames(),
+                domain.getWins(),
+                domain.getTotalBans(),
+                domain.getTotalMatchesInDimension(),
+                domain.getAvgKills(),
+                domain.getAvgDeaths(),
+                domain.getAvgAssists(),
+                domain.getAvgCs(),
+                domain.getAvgGold()
+        );
+    }
+}

--- a/infra/persistence/build.gradle
+++ b/infra/persistence/build.gradle
@@ -1,3 +1,11 @@
+sourceSets {
+    main {
+        resources {
+            srcDir "${rootProject.projectDir}/lol-db-schema"
+        }
+    }
+}
+
 dependencies {
     implementation project(':core:domain')
     implementation project(':core:enum')
@@ -6,5 +14,12 @@ dependencies {
 
     // JPA
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    // Flyway
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-database-postgresql'
+
+    // Jackson (캐시 직렬화)
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
     runtimeOnly 'org.postgresql:postgresql'
 }

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/entity/ChampionItemStatEntity.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/entity/ChampionItemStatEntity.java
@@ -2,6 +2,7 @@ package com.mmrtr.lol.infra.persistence.champion_stat.entity;
 
 import com.mmrtr.lol.infra.persistence.champion_stat.entity.value.StatDimensionValue;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,7 +12,7 @@ import org.hibernate.annotations.Comment;
 @Entity
 @Getter
 @Builder
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Table(name = "champion_item_stat")
 public class ChampionItemStatEntity {

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/entity/ChampionItemStatEntity.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/entity/ChampionItemStatEntity.java
@@ -1,0 +1,39 @@
+package com.mmrtr.lol.infra.persistence.champion_stat.entity;
+
+import com.mmrtr.lol.infra.persistence.champion_stat.entity.value.StatDimensionValue;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "champion_item_stat")
+public class ChampionItemStatEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Comment("챔피언 아이템 통계 ID")
+    @Column(name = "champion_item_stat_id")
+    private Long id;
+
+    @Embedded
+    private StatDimensionValue dimension;
+
+    @Comment("빌드 타입 (STARTER, BOOTS, CORE)")
+    private String buildType;
+
+    @Comment("아이템 ID 목록 (정렬 CSV)")
+    private String itemIds;
+
+    @Comment("게임 수")
+    private long games;
+
+    @Comment("승리 수")
+    private long wins;
+}

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/entity/ChampionMatchupStatEntity.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/entity/ChampionMatchupStatEntity.java
@@ -1,0 +1,50 @@
+package com.mmrtr.lol.infra.persistence.champion_stat.entity;
+
+import com.mmrtr.lol.infra.persistence.champion_stat.entity.value.StatDimensionValue;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+import java.math.BigDecimal;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "champion_matchup_stat")
+public class ChampionMatchupStatEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Comment("챔피언 매치업 통계 ID")
+    @Column(name = "champion_matchup_stat_id")
+    private Long id;
+
+    @Embedded
+    private StatDimensionValue dimension;
+
+    @Comment("상대 챔피언 ID")
+    private int opponentChampionId;
+
+    @Comment("게임 수")
+    private long games;
+
+    @Comment("승리 수")
+    private long wins;
+
+    @Comment("평균 킬")
+    private BigDecimal avgKills;
+
+    @Comment("평균 데스")
+    private BigDecimal avgDeaths;
+
+    @Comment("평균 어시스트")
+    private BigDecimal avgAssists;
+
+    @Comment("평균 골드 차이")
+    private BigDecimal avgGoldDiff;
+}

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/entity/ChampionMatchupStatEntity.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/entity/ChampionMatchupStatEntity.java
@@ -2,6 +2,7 @@ package com.mmrtr.lol.infra.persistence.champion_stat.entity;
 
 import com.mmrtr.lol.infra.persistence.champion_stat.entity.value.StatDimensionValue;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,7 +14,7 @@ import java.math.BigDecimal;
 @Entity
 @Getter
 @Builder
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Table(name = "champion_matchup_stat")
 public class ChampionMatchupStatEntity {

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/entity/ChampionRuneStatEntity.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/entity/ChampionRuneStatEntity.java
@@ -2,6 +2,7 @@ package com.mmrtr.lol.infra.persistence.champion_stat.entity;
 
 import com.mmrtr.lol.infra.persistence.champion_stat.entity.value.StatDimensionValue;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,7 +12,7 @@ import org.hibernate.annotations.Comment;
 @Entity
 @Getter
 @Builder
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Table(name = "champion_rune_stat")
 public class ChampionRuneStatEntity {

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/entity/ChampionRuneStatEntity.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/entity/ChampionRuneStatEntity.java
@@ -1,0 +1,54 @@
+package com.mmrtr.lol.infra.persistence.champion_stat.entity;
+
+import com.mmrtr.lol.infra.persistence.champion_stat.entity.value.StatDimensionValue;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "champion_rune_stat")
+public class ChampionRuneStatEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Comment("챔피언 룬 통계 ID")
+    @Column(name = "champion_rune_stat_id")
+    private Long id;
+
+    @Embedded
+    private StatDimensionValue dimension;
+
+    @Comment("주 룬 ID")
+    private int primaryRuneId;
+
+    @Comment("주 룬 세부 ID 목록 (CSV)")
+    private String primaryRuneIds;
+
+    @Comment("보조 룬 ID")
+    private int secondaryRuneId;
+
+    @Comment("보조 룬 세부 ID 목록 (CSV)")
+    private String secondaryRuneIds;
+
+    @Comment("공격 룬 스탯")
+    private int statOffense;
+
+    @Comment("유연 룬 스탯")
+    private int statFlex;
+
+    @Comment("방어 룬 스탯")
+    private int statDefense;
+
+    @Comment("게임 수")
+    private long games;
+
+    @Comment("승리 수")
+    private long wins;
+}

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/entity/ChampionSkillStatEntity.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/entity/ChampionSkillStatEntity.java
@@ -2,6 +2,7 @@ package com.mmrtr.lol.infra.persistence.champion_stat.entity;
 
 import com.mmrtr.lol.infra.persistence.champion_stat.entity.value.StatDimensionValue;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,7 +12,7 @@ import org.hibernate.annotations.Comment;
 @Entity
 @Getter
 @Builder
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Table(name = "champion_skill_stat")
 public class ChampionSkillStatEntity {

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/entity/ChampionSkillStatEntity.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/entity/ChampionSkillStatEntity.java
@@ -1,0 +1,39 @@
+package com.mmrtr.lol.infra.persistence.champion_stat.entity;
+
+import com.mmrtr.lol.infra.persistence.champion_stat.entity.value.StatDimensionValue;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "champion_skill_stat")
+public class ChampionSkillStatEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Comment("챔피언 스킬 통계 ID")
+    @Column(name = "champion_skill_stat_id")
+    private Long id;
+
+    @Embedded
+    private StatDimensionValue dimension;
+
+    @Comment("스킬 순서 (CSV)")
+    private String skillOrder;
+
+    @Comment("스킬 우선순위 (예: Q>E>W)")
+    private String skillPriority;
+
+    @Comment("게임 수")
+    private long games;
+
+    @Comment("승리 수")
+    private long wins;
+}

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/entity/ChampionSpellStatEntity.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/entity/ChampionSpellStatEntity.java
@@ -2,6 +2,7 @@ package com.mmrtr.lol.infra.persistence.champion_stat.entity;
 
 import com.mmrtr.lol.infra.persistence.champion_stat.entity.value.StatDimensionValue;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,7 +12,7 @@ import org.hibernate.annotations.Comment;
 @Entity
 @Getter
 @Builder
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Table(name = "champion_spell_stat")
 public class ChampionSpellStatEntity {

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/entity/ChampionSpellStatEntity.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/entity/ChampionSpellStatEntity.java
@@ -1,0 +1,39 @@
+package com.mmrtr.lol.infra.persistence.champion_stat.entity;
+
+import com.mmrtr.lol.infra.persistence.champion_stat.entity.value.StatDimensionValue;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "champion_spell_stat")
+public class ChampionSpellStatEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Comment("챔피언 스펠 통계 ID")
+    @Column(name = "champion_spell_stat_id")
+    private Long id;
+
+    @Embedded
+    private StatDimensionValue dimension;
+
+    @Comment("소환사 주문 1 ID (작은 값)")
+    private int spell1Id;
+
+    @Comment("소환사 주문 2 ID (큰 값)")
+    private int spell2Id;
+
+    @Comment("게임 수")
+    private long games;
+
+    @Comment("승리 수")
+    private long wins;
+}

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/entity/ChampionStatSummaryEntity.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/entity/ChampionStatSummaryEntity.java
@@ -1,0 +1,56 @@
+package com.mmrtr.lol.infra.persistence.champion_stat.entity;
+
+import com.mmrtr.lol.infra.persistence.champion_stat.entity.value.StatDimensionValue;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+import java.math.BigDecimal;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "champion_stat_summary")
+public class ChampionStatSummaryEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Comment("챔피언 통계 요약 ID")
+    @Column(name = "champion_stat_summary_id")
+    private Long id;
+
+    @Embedded
+    private StatDimensionValue dimension;
+
+    @Comment("총 게임 수")
+    private long totalGames;
+
+    @Comment("승리 수")
+    private long wins;
+
+    @Comment("총 밴 수")
+    private long totalBans;
+
+    @Comment("해당 차원 총 매치 수")
+    private long totalMatchesInDimension;
+
+    @Comment("평균 킬")
+    private BigDecimal avgKills;
+
+    @Comment("평균 데스")
+    private BigDecimal avgDeaths;
+
+    @Comment("평균 어시스트")
+    private BigDecimal avgAssists;
+
+    @Comment("평균 CS")
+    private BigDecimal avgCs;
+
+    @Comment("평균 골드")
+    private BigDecimal avgGold;
+}

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/entity/ChampionStatSummaryEntity.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/entity/ChampionStatSummaryEntity.java
@@ -2,6 +2,7 @@ package com.mmrtr.lol.infra.persistence.champion_stat.entity;
 
 import com.mmrtr.lol.infra.persistence.champion_stat.entity.value.StatDimensionValue;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,7 +14,7 @@ import java.math.BigDecimal;
 @Entity
 @Getter
 @Builder
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Table(name = "champion_stat_summary")
 public class ChampionStatSummaryEntity {

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/entity/ItemMetadataEntity.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/entity/ItemMetadataEntity.java
@@ -1,0 +1,31 @@
+package com.mmrtr.lol.infra.persistence.champion_stat.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "item_metadata")
+public class ItemMetadataEntity {
+
+    @Id
+    @Comment("RIOT 아이템 ID")
+    @Column(name = "item_id")
+    private int itemId;
+
+    @Comment("아이템 이름")
+    private String itemName;
+
+    @Comment("아이템 분류")
+    private String itemCategory;
+
+    @Comment("적용 패치 버전")
+    private String gameVersion;
+}

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/entity/ItemMetadataEntity.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/entity/ItemMetadataEntity.java
@@ -1,6 +1,7 @@
 package com.mmrtr.lol.infra.persistence.champion_stat.entity;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,7 +11,7 @@ import org.hibernate.annotations.Comment;
 @Entity
 @Getter
 @Builder
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Table(name = "item_metadata")
 public class ItemMetadataEntity {

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/entity/value/StatDimensionValue.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/entity/value/StatDimensionValue.java
@@ -1,0 +1,43 @@
+package com.mmrtr.lol.infra.persistence.champion_stat.entity.value;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.*;
+import org.hibernate.annotations.Comment;
+
+@Getter
+@Setter
+@Embeddable
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class StatDimensionValue {
+
+    @Comment("챔피언 ID")
+    @Column(name = "champion_id")
+    private int championId;
+
+    @Comment("팀 포지션")
+    @Column(name = "team_position")
+    private String teamPosition;
+
+    @Comment("시즌")
+    @Column(name = "season")
+    private int season;
+
+    @Comment("티어 그룹")
+    @Column(name = "tier_group")
+    private String tierGroup;
+
+    @Comment("플랫폼 ID")
+    @Column(name = "platform_id")
+    private String platformId;
+
+    @Comment("큐 ID")
+    @Column(name = "queue_id")
+    private int queueId;
+
+    @Comment("게임 버전")
+    @Column(name = "game_version")
+    private String gameVersion;
+}

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/entity/value/StatDimensionValue.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/entity/value/StatDimensionValue.java
@@ -6,10 +6,9 @@ import lombok.*;
 import org.hibernate.annotations.Comment;
 
 @Getter
-@Setter
 @Embeddable
 @Builder
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class StatDimensionValue {
 

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/repository/ChampionItemStatJpaRepository.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/repository/ChampionItemStatJpaRepository.java
@@ -1,0 +1,16 @@
+package com.mmrtr.lol.infra.persistence.champion_stat.repository;
+
+import com.mmrtr.lol.infra.persistence.champion_stat.entity.ChampionItemStatEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ChampionItemStatJpaRepository extends JpaRepository<ChampionItemStatEntity, Long> {
+
+    void deleteByDimensionSeasonAndDimensionQueueId(int season, int queueId);
+
+    List<ChampionItemStatEntity> findByDimensionChampionIdAndDimensionTeamPositionAndDimensionSeasonAndDimensionTierGroupAndDimensionPlatformIdAndDimensionQueueIdAndDimensionGameVersion(
+            int championId, String teamPosition, int season, String tierGroup, String platformId, int queueId, String gameVersion);
+}

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/repository/ChampionMatchupStatJpaRepository.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/repository/ChampionMatchupStatJpaRepository.java
@@ -1,0 +1,16 @@
+package com.mmrtr.lol.infra.persistence.champion_stat.repository;
+
+import com.mmrtr.lol.infra.persistence.champion_stat.entity.ChampionMatchupStatEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ChampionMatchupStatJpaRepository extends JpaRepository<ChampionMatchupStatEntity, Long> {
+
+    void deleteByDimensionSeasonAndDimensionQueueId(int season, int queueId);
+
+    List<ChampionMatchupStatEntity> findByDimensionChampionIdAndDimensionTeamPositionAndDimensionSeasonAndDimensionTierGroupAndDimensionPlatformIdAndDimensionQueueIdAndDimensionGameVersion(
+            int championId, String teamPosition, int season, String tierGroup, String platformId, int queueId, String gameVersion);
+}

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/repository/ChampionRuneStatJpaRepository.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/repository/ChampionRuneStatJpaRepository.java
@@ -1,0 +1,16 @@
+package com.mmrtr.lol.infra.persistence.champion_stat.repository;
+
+import com.mmrtr.lol.infra.persistence.champion_stat.entity.ChampionRuneStatEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ChampionRuneStatJpaRepository extends JpaRepository<ChampionRuneStatEntity, Long> {
+
+    void deleteByDimensionSeasonAndDimensionQueueId(int season, int queueId);
+
+    List<ChampionRuneStatEntity> findByDimensionChampionIdAndDimensionTeamPositionAndDimensionSeasonAndDimensionTierGroupAndDimensionPlatformIdAndDimensionQueueIdAndDimensionGameVersion(
+            int championId, String teamPosition, int season, String tierGroup, String platformId, int queueId, String gameVersion);
+}

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/repository/ChampionSkillStatJpaRepository.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/repository/ChampionSkillStatJpaRepository.java
@@ -1,0 +1,16 @@
+package com.mmrtr.lol.infra.persistence.champion_stat.repository;
+
+import com.mmrtr.lol.infra.persistence.champion_stat.entity.ChampionSkillStatEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ChampionSkillStatJpaRepository extends JpaRepository<ChampionSkillStatEntity, Long> {
+
+    void deleteByDimensionSeasonAndDimensionQueueId(int season, int queueId);
+
+    List<ChampionSkillStatEntity> findByDimensionChampionIdAndDimensionTeamPositionAndDimensionSeasonAndDimensionTierGroupAndDimensionPlatformIdAndDimensionQueueIdAndDimensionGameVersion(
+            int championId, String teamPosition, int season, String tierGroup, String platformId, int queueId, String gameVersion);
+}

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/repository/ChampionSpellStatJpaRepository.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/repository/ChampionSpellStatJpaRepository.java
@@ -1,0 +1,16 @@
+package com.mmrtr.lol.infra.persistence.champion_stat.repository;
+
+import com.mmrtr.lol.infra.persistence.champion_stat.entity.ChampionSpellStatEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ChampionSpellStatJpaRepository extends JpaRepository<ChampionSpellStatEntity, Long> {
+
+    void deleteByDimensionSeasonAndDimensionQueueId(int season, int queueId);
+
+    List<ChampionSpellStatEntity> findByDimensionChampionIdAndDimensionTeamPositionAndDimensionSeasonAndDimensionTierGroupAndDimensionPlatformIdAndDimensionQueueIdAndDimensionGameVersion(
+            int championId, String teamPosition, int season, String tierGroup, String platformId, int queueId, String gameVersion);
+}

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/repository/ChampionStatRepositoryImpl.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/repository/ChampionStatRepositoryImpl.java
@@ -116,7 +116,7 @@ public class ChampionStatRepositoryImpl implements ChampionStatRepositoryPort {
 
         String sql = "INSERT INTO champion_spell_stat (" +
                 "champion_id, team_position, season, tier_group, platform_id, queue_id, game_version, " +
-                "spell1id, spell2id, games, wins" +
+                "spell1_id, spell2_id, games, wins" +
                 ") VALUES (" +
                 ":championId, :teamPosition, :season, :tierGroup, :platformId, :queueId, :gameVersion, " +
                 ":spell1Id, :spell2Id, :games, :wins)";

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/repository/ChampionStatRepositoryImpl.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/repository/ChampionStatRepositoryImpl.java
@@ -1,0 +1,410 @@
+package com.mmrtr.lol.infra.persistence.champion_stat.repository;
+
+import com.mmrtr.lol.domain.champion_stat.domain.*;
+import com.mmrtr.lol.domain.champion_stat.repository.ChampionStatRepositoryPort;
+import com.mmrtr.lol.infra.persistence.champion_stat.entity.*;
+import com.mmrtr.lol.infra.persistence.champion_stat.entity.value.StatDimensionValue;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ChampionStatRepositoryImpl implements ChampionStatRepositoryPort {
+
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+    private final ChampionStatSummaryJpaRepository summaryJpaRepository;
+    private final ChampionRuneStatJpaRepository runeStatJpaRepository;
+    private final ChampionSpellStatJpaRepository spellStatJpaRepository;
+    private final ChampionSkillStatJpaRepository skillStatJpaRepository;
+    private final ChampionItemStatJpaRepository itemStatJpaRepository;
+    private final ChampionMatchupStatJpaRepository matchupStatJpaRepository;
+
+    @Override
+    @Transactional
+    public void deleteAllBySeasonAndQueueId(int season, int queueId) {
+        summaryJpaRepository.deleteByDimensionSeasonAndDimensionQueueId(season, queueId);
+        runeStatJpaRepository.deleteByDimensionSeasonAndDimensionQueueId(season, queueId);
+        spellStatJpaRepository.deleteByDimensionSeasonAndDimensionQueueId(season, queueId);
+        skillStatJpaRepository.deleteByDimensionSeasonAndDimensionQueueId(season, queueId);
+        itemStatJpaRepository.deleteByDimensionSeasonAndDimensionQueueId(season, queueId);
+        matchupStatJpaRepository.deleteByDimensionSeasonAndDimensionQueueId(season, queueId);
+    }
+
+    // === 벌크 저장 ===
+
+    @Override
+    public void bulkSaveSummaries(List<ChampionStatSummary> summaries) {
+        if (summaries.isEmpty()) return;
+
+        String sql = "INSERT INTO champion_stat_summary (" +
+                "champion_id, team_position, season, tier_group, platform_id, queue_id, game_version, " +
+                "total_games, wins, total_bans, total_matches_in_dimension, " +
+                "avg_kills, avg_deaths, avg_assists, avg_cs, avg_gold" +
+                ") VALUES (" +
+                ":championId, :teamPosition, :season, :tierGroup, :platformId, :queueId, :gameVersion, " +
+                ":totalGames, :wins, :totalBans, :totalMatchesInDimension, " +
+                ":avgKills, :avgDeaths, :avgAssists, :avgCs, :avgGold)";
+
+        SqlParameterSource[] params = summaries.stream()
+                .map(s -> new MapSqlParameterSource()
+                        .addValue("championId", s.getChampionId())
+                        .addValue("teamPosition", s.getTeamPosition())
+                        .addValue("season", s.getSeason())
+                        .addValue("tierGroup", s.getTierGroup())
+                        .addValue("platformId", s.getPlatformId())
+                        .addValue("queueId", s.getQueueId())
+                        .addValue("gameVersion", s.getGameVersion())
+                        .addValue("totalGames", s.getTotalGames())
+                        .addValue("wins", s.getWins())
+                        .addValue("totalBans", s.getTotalBans())
+                        .addValue("totalMatchesInDimension", s.getTotalMatchesInDimension())
+                        .addValue("avgKills", s.getAvgKills())
+                        .addValue("avgDeaths", s.getAvgDeaths())
+                        .addValue("avgAssists", s.getAvgAssists())
+                        .addValue("avgCs", s.getAvgCs())
+                        .addValue("avgGold", s.getAvgGold()))
+                .toArray(SqlParameterSource[]::new);
+
+        jdbcTemplate.batchUpdate(sql, params);
+    }
+
+    @Override
+    public void bulkSaveRuneStats(List<ChampionRuneStat> runeStats) {
+        if (runeStats.isEmpty()) return;
+
+        String sql = "INSERT INTO champion_rune_stat (" +
+                "champion_id, team_position, season, tier_group, platform_id, queue_id, game_version, " +
+                "primary_rune_id, primary_rune_ids, secondary_rune_id, secondary_rune_ids, " +
+                "stat_offense, stat_flex, stat_defense, games, wins" +
+                ") VALUES (" +
+                ":championId, :teamPosition, :season, :tierGroup, :platformId, :queueId, :gameVersion, " +
+                ":primaryRuneId, :primaryRuneIds, :secondaryRuneId, :secondaryRuneIds, " +
+                ":statOffense, :statFlex, :statDefense, :games, :wins)";
+
+        SqlParameterSource[] params = runeStats.stream()
+                .map(r -> new MapSqlParameterSource()
+                        .addValue("championId", r.getChampionId())
+                        .addValue("teamPosition", r.getTeamPosition())
+                        .addValue("season", r.getSeason())
+                        .addValue("tierGroup", r.getTierGroup())
+                        .addValue("platformId", r.getPlatformId())
+                        .addValue("queueId", r.getQueueId())
+                        .addValue("gameVersion", r.getGameVersion())
+                        .addValue("primaryRuneId", r.getPrimaryRuneId())
+                        .addValue("primaryRuneIds", r.getPrimaryRuneIds())
+                        .addValue("secondaryRuneId", r.getSecondaryRuneId())
+                        .addValue("secondaryRuneIds", r.getSecondaryRuneIds())
+                        .addValue("statOffense", r.getStatOffense())
+                        .addValue("statFlex", r.getStatFlex())
+                        .addValue("statDefense", r.getStatDefense())
+                        .addValue("games", r.getGames())
+                        .addValue("wins", r.getWins()))
+                .toArray(SqlParameterSource[]::new);
+
+        jdbcTemplate.batchUpdate(sql, params);
+    }
+
+    @Override
+    public void bulkSaveSpellStats(List<ChampionSpellStat> spellStats) {
+        if (spellStats.isEmpty()) return;
+
+        String sql = "INSERT INTO champion_spell_stat (" +
+                "champion_id, team_position, season, tier_group, platform_id, queue_id, game_version, " +
+                "spell1id, spell2id, games, wins" +
+                ") VALUES (" +
+                ":championId, :teamPosition, :season, :tierGroup, :platformId, :queueId, :gameVersion, " +
+                ":spell1Id, :spell2Id, :games, :wins)";
+
+        SqlParameterSource[] params = spellStats.stream()
+                .map(s -> new MapSqlParameterSource()
+                        .addValue("championId", s.getChampionId())
+                        .addValue("teamPosition", s.getTeamPosition())
+                        .addValue("season", s.getSeason())
+                        .addValue("tierGroup", s.getTierGroup())
+                        .addValue("platformId", s.getPlatformId())
+                        .addValue("queueId", s.getQueueId())
+                        .addValue("gameVersion", s.getGameVersion())
+                        .addValue("spell1Id", s.getSpell1Id())
+                        .addValue("spell2Id", s.getSpell2Id())
+                        .addValue("games", s.getGames())
+                        .addValue("wins", s.getWins()))
+                .toArray(SqlParameterSource[]::new);
+
+        jdbcTemplate.batchUpdate(sql, params);
+    }
+
+    @Override
+    public void bulkSaveSkillStats(List<ChampionSkillStat> skillStats) {
+        if (skillStats.isEmpty()) return;
+
+        String sql = "INSERT INTO champion_skill_stat (" +
+                "champion_id, team_position, season, tier_group, platform_id, queue_id, game_version, " +
+                "skill_order, skill_priority, games, wins" +
+                ") VALUES (" +
+                ":championId, :teamPosition, :season, :tierGroup, :platformId, :queueId, :gameVersion, " +
+                ":skillOrder, :skillPriority, :games, :wins)";
+
+        SqlParameterSource[] params = skillStats.stream()
+                .map(s -> new MapSqlParameterSource()
+                        .addValue("championId", s.getChampionId())
+                        .addValue("teamPosition", s.getTeamPosition())
+                        .addValue("season", s.getSeason())
+                        .addValue("tierGroup", s.getTierGroup())
+                        .addValue("platformId", s.getPlatformId())
+                        .addValue("queueId", s.getQueueId())
+                        .addValue("gameVersion", s.getGameVersion())
+                        .addValue("skillOrder", s.getSkillOrder())
+                        .addValue("skillPriority", s.getSkillPriority())
+                        .addValue("games", s.getGames())
+                        .addValue("wins", s.getWins()))
+                .toArray(SqlParameterSource[]::new);
+
+        jdbcTemplate.batchUpdate(sql, params);
+    }
+
+    @Override
+    public void bulkSaveItemStats(List<ChampionItemStat> itemStats) {
+        if (itemStats.isEmpty()) return;
+
+        String sql = "INSERT INTO champion_item_stat (" +
+                "champion_id, team_position, season, tier_group, platform_id, queue_id, game_version, " +
+                "build_type, item_ids, games, wins" +
+                ") VALUES (" +
+                ":championId, :teamPosition, :season, :tierGroup, :platformId, :queueId, :gameVersion, " +
+                ":buildType, :itemIds, :games, :wins)";
+
+        SqlParameterSource[] params = itemStats.stream()
+                .map(i -> new MapSqlParameterSource()
+                        .addValue("championId", i.getChampionId())
+                        .addValue("teamPosition", i.getTeamPosition())
+                        .addValue("season", i.getSeason())
+                        .addValue("tierGroup", i.getTierGroup())
+                        .addValue("platformId", i.getPlatformId())
+                        .addValue("queueId", i.getQueueId())
+                        .addValue("gameVersion", i.getGameVersion())
+                        .addValue("buildType", i.getBuildType())
+                        .addValue("itemIds", i.getItemIds())
+                        .addValue("games", i.getGames())
+                        .addValue("wins", i.getWins()))
+                .toArray(SqlParameterSource[]::new);
+
+        jdbcTemplate.batchUpdate(sql, params);
+    }
+
+    @Override
+    public void bulkSaveMatchupStats(List<ChampionMatchupStat> matchupStats) {
+        if (matchupStats.isEmpty()) return;
+
+        String sql = "INSERT INTO champion_matchup_stat (" +
+                "champion_id, team_position, season, tier_group, platform_id, queue_id, game_version, " +
+                "opponent_champion_id, games, wins, avg_kills, avg_deaths, avg_assists, avg_gold_diff" +
+                ") VALUES (" +
+                ":championId, :teamPosition, :season, :tierGroup, :platformId, :queueId, :gameVersion, " +
+                ":opponentChampionId, :games, :wins, :avgKills, :avgDeaths, :avgAssists, :avgGoldDiff)";
+
+        SqlParameterSource[] params = matchupStats.stream()
+                .map(m -> new MapSqlParameterSource()
+                        .addValue("championId", m.getChampionId())
+                        .addValue("teamPosition", m.getTeamPosition())
+                        .addValue("season", m.getSeason())
+                        .addValue("tierGroup", m.getTierGroup())
+                        .addValue("platformId", m.getPlatformId())
+                        .addValue("queueId", m.getQueueId())
+                        .addValue("gameVersion", m.getGameVersion())
+                        .addValue("opponentChampionId", m.getOpponentChampionId())
+                        .addValue("games", m.getGames())
+                        .addValue("wins", m.getWins())
+                        .addValue("avgKills", m.getAvgKills())
+                        .addValue("avgDeaths", m.getAvgDeaths())
+                        .addValue("avgAssists", m.getAvgAssists())
+                        .addValue("avgGoldDiff", m.getAvgGoldDiff()))
+                .toArray(SqlParameterSource[]::new);
+
+        jdbcTemplate.batchUpdate(sql, params);
+    }
+
+    // === 조회 ===
+
+    @Override
+    public List<ChampionStatSummary> findSummaries(int championId, String teamPosition, int season, String tierGroup, String platformId, int queueId, String gameVersion) {
+        return summaryJpaRepository.findByDimensionChampionIdAndDimensionTeamPositionAndDimensionSeasonAndDimensionTierGroupAndDimensionPlatformIdAndDimensionQueueIdAndDimensionGameVersion(
+                championId, teamPosition, season, tierGroup, platformId, queueId, gameVersion)
+                .stream()
+                .map(this::toDomain)
+                .toList();
+    }
+
+    @Override
+    public List<ChampionRuneStat> findRuneStats(int championId, String teamPosition, int season, String tierGroup, String platformId, int queueId, String gameVersion) {
+        return runeStatJpaRepository.findByDimensionChampionIdAndDimensionTeamPositionAndDimensionSeasonAndDimensionTierGroupAndDimensionPlatformIdAndDimensionQueueIdAndDimensionGameVersion(
+                championId, teamPosition, season, tierGroup, platformId, queueId, gameVersion)
+                .stream()
+                .map(this::toDomain)
+                .toList();
+    }
+
+    @Override
+    public List<ChampionSpellStat> findSpellStats(int championId, String teamPosition, int season, String tierGroup, String platformId, int queueId, String gameVersion) {
+        return spellStatJpaRepository.findByDimensionChampionIdAndDimensionTeamPositionAndDimensionSeasonAndDimensionTierGroupAndDimensionPlatformIdAndDimensionQueueIdAndDimensionGameVersion(
+                championId, teamPosition, season, tierGroup, platformId, queueId, gameVersion)
+                .stream()
+                .map(this::toDomain)
+                .toList();
+    }
+
+    @Override
+    public List<ChampionSkillStat> findSkillStats(int championId, String teamPosition, int season, String tierGroup, String platformId, int queueId, String gameVersion) {
+        return skillStatJpaRepository.findByDimensionChampionIdAndDimensionTeamPositionAndDimensionSeasonAndDimensionTierGroupAndDimensionPlatformIdAndDimensionQueueIdAndDimensionGameVersion(
+                championId, teamPosition, season, tierGroup, platformId, queueId, gameVersion)
+                .stream()
+                .map(this::toDomain)
+                .toList();
+    }
+
+    @Override
+    public List<ChampionItemStat> findItemStats(int championId, String teamPosition, int season, String tierGroup, String platformId, int queueId, String gameVersion) {
+        return itemStatJpaRepository.findByDimensionChampionIdAndDimensionTeamPositionAndDimensionSeasonAndDimensionTierGroupAndDimensionPlatformIdAndDimensionQueueIdAndDimensionGameVersion(
+                championId, teamPosition, season, tierGroup, platformId, queueId, gameVersion)
+                .stream()
+                .map(this::toDomain)
+                .toList();
+    }
+
+    @Override
+    public List<ChampionMatchupStat> findMatchupStats(int championId, String teamPosition, int season, String tierGroup, String platformId, int queueId, String gameVersion) {
+        return matchupStatJpaRepository.findByDimensionChampionIdAndDimensionTeamPositionAndDimensionSeasonAndDimensionTierGroupAndDimensionPlatformIdAndDimensionQueueIdAndDimensionGameVersion(
+                championId, teamPosition, season, tierGroup, platformId, queueId, gameVersion)
+                .stream()
+                .map(this::toDomain)
+                .toList();
+    }
+
+    // === Entity → Domain 변환 ===
+
+    private ChampionStatSummary toDomain(ChampionStatSummaryEntity e) {
+        StatDimensionValue d = e.getDimension();
+        return ChampionStatSummary.builder()
+                .id(e.getId())
+                .championId(d.getChampionId())
+                .teamPosition(d.getTeamPosition())
+                .season(d.getSeason())
+                .tierGroup(d.getTierGroup())
+                .platformId(d.getPlatformId())
+                .queueId(d.getQueueId())
+                .gameVersion(d.getGameVersion())
+                .totalGames(e.getTotalGames())
+                .wins(e.getWins())
+                .totalBans(e.getTotalBans())
+                .totalMatchesInDimension(e.getTotalMatchesInDimension())
+                .avgKills(e.getAvgKills())
+                .avgDeaths(e.getAvgDeaths())
+                .avgAssists(e.getAvgAssists())
+                .avgCs(e.getAvgCs())
+                .avgGold(e.getAvgGold())
+                .build();
+    }
+
+    private ChampionRuneStat toDomain(ChampionRuneStatEntity e) {
+        StatDimensionValue d = e.getDimension();
+        return ChampionRuneStat.builder()
+                .id(e.getId())
+                .championId(d.getChampionId())
+                .teamPosition(d.getTeamPosition())
+                .season(d.getSeason())
+                .tierGroup(d.getTierGroup())
+                .platformId(d.getPlatformId())
+                .queueId(d.getQueueId())
+                .gameVersion(d.getGameVersion())
+                .primaryRuneId(e.getPrimaryRuneId())
+                .primaryRuneIds(e.getPrimaryRuneIds())
+                .secondaryRuneId(e.getSecondaryRuneId())
+                .secondaryRuneIds(e.getSecondaryRuneIds())
+                .statOffense(e.getStatOffense())
+                .statFlex(e.getStatFlex())
+                .statDefense(e.getStatDefense())
+                .games(e.getGames())
+                .wins(e.getWins())
+                .build();
+    }
+
+    private ChampionSpellStat toDomain(ChampionSpellStatEntity e) {
+        StatDimensionValue d = e.getDimension();
+        return ChampionSpellStat.builder()
+                .id(e.getId())
+                .championId(d.getChampionId())
+                .teamPosition(d.getTeamPosition())
+                .season(d.getSeason())
+                .tierGroup(d.getTierGroup())
+                .platformId(d.getPlatformId())
+                .queueId(d.getQueueId())
+                .gameVersion(d.getGameVersion())
+                .spell1Id(e.getSpell1Id())
+                .spell2Id(e.getSpell2Id())
+                .games(e.getGames())
+                .wins(e.getWins())
+                .build();
+    }
+
+    private ChampionSkillStat toDomain(ChampionSkillStatEntity e) {
+        StatDimensionValue d = e.getDimension();
+        return ChampionSkillStat.builder()
+                .id(e.getId())
+                .championId(d.getChampionId())
+                .teamPosition(d.getTeamPosition())
+                .season(d.getSeason())
+                .tierGroup(d.getTierGroup())
+                .platformId(d.getPlatformId())
+                .queueId(d.getQueueId())
+                .gameVersion(d.getGameVersion())
+                .skillOrder(e.getSkillOrder())
+                .skillPriority(e.getSkillPriority())
+                .games(e.getGames())
+                .wins(e.getWins())
+                .build();
+    }
+
+    private ChampionItemStat toDomain(ChampionItemStatEntity e) {
+        StatDimensionValue d = e.getDimension();
+        return ChampionItemStat.builder()
+                .id(e.getId())
+                .championId(d.getChampionId())
+                .teamPosition(d.getTeamPosition())
+                .season(d.getSeason())
+                .tierGroup(d.getTierGroup())
+                .platformId(d.getPlatformId())
+                .queueId(d.getQueueId())
+                .gameVersion(d.getGameVersion())
+                .buildType(e.getBuildType())
+                .itemIds(e.getItemIds())
+                .games(e.getGames())
+                .wins(e.getWins())
+                .build();
+    }
+
+    private ChampionMatchupStat toDomain(ChampionMatchupStatEntity e) {
+        StatDimensionValue d = e.getDimension();
+        return ChampionMatchupStat.builder()
+                .id(e.getId())
+                .championId(d.getChampionId())
+                .teamPosition(d.getTeamPosition())
+                .season(d.getSeason())
+                .tierGroup(d.getTierGroup())
+                .platformId(d.getPlatformId())
+                .queueId(d.getQueueId())
+                .gameVersion(d.getGameVersion())
+                .opponentChampionId(e.getOpponentChampionId())
+                .games(e.getGames())
+                .wins(e.getWins())
+                .avgKills(e.getAvgKills())
+                .avgDeaths(e.getAvgDeaths())
+                .avgAssists(e.getAvgAssists())
+                .avgGoldDiff(e.getAvgGoldDiff())
+                .build();
+    }
+}

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/repository/ChampionStatSummaryJpaRepository.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/repository/ChampionStatSummaryJpaRepository.java
@@ -1,0 +1,16 @@
+package com.mmrtr.lol.infra.persistence.champion_stat.repository;
+
+import com.mmrtr.lol.infra.persistence.champion_stat.entity.ChampionStatSummaryEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ChampionStatSummaryJpaRepository extends JpaRepository<ChampionStatSummaryEntity, Long> {
+
+    void deleteByDimensionSeasonAndDimensionQueueId(int season, int queueId);
+
+    List<ChampionStatSummaryEntity> findByDimensionChampionIdAndDimensionTeamPositionAndDimensionSeasonAndDimensionTierGroupAndDimensionPlatformIdAndDimensionQueueIdAndDimensionGameVersion(
+            int championId, String teamPosition, int season, String tierGroup, String platformId, int queueId, String gameVersion);
+}

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/repository/ItemMetadataJpaRepository.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/repository/ItemMetadataJpaRepository.java
@@ -1,0 +1,7 @@
+package com.mmrtr.lol.infra.persistence.champion_stat.repository;
+
+import com.mmrtr.lol.infra.persistence.champion_stat.entity.ItemMetadataEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ItemMetadataJpaRepository extends JpaRepository<ItemMetadataEntity, Integer> {
+}

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/service/ChampionStatAggregationService.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/service/ChampionStatAggregationService.java
@@ -168,16 +168,16 @@ public class ChampionStatAggregationService implements TriggerChampionStatAggreg
         Map<Integer, Long> finalBanCounts = banCounts;
         List<ChampionStatSummary> summaries = rows.stream()
                 .map(row -> ChampionStatSummary.builder()
-                        .championId(((Number) row.get("champion_id")).intValue())
+                        .championId(toInt(row.get("champion_id")))
                         .teamPosition((String) row.get("team_position"))
                         .season(season)
                         .tierGroup(tierGroupName)
                         .platformId(platformId)
                         .queueId(queueId)
                         .gameVersion(gameVersion)
-                        .totalGames(((Number) row.get("total_games")).longValue())
-                        .wins(((Number) row.get("wins")).longValue())
-                        .totalBans(finalBanCounts.getOrDefault(((Number) row.get("champion_id")).intValue(), 0L))
+                        .totalGames(toLong(row.get("total_games")))
+                        .wins(toLong(row.get("wins")))
+                        .totalBans(finalBanCounts.getOrDefault(toInt(row.get("champion_id")), 0L))
                         .totalMatchesInDimension(totalMatches)
                         .avgKills(toBigDecimal(row.get("avg_kills")))
                         .avgDeaths(toBigDecimal(row.get("avg_deaths")))
@@ -214,22 +214,22 @@ public class ChampionStatAggregationService implements TriggerChampionStatAggreg
 
         List<ChampionRuneStat> runeStats = rows.stream()
                 .map(row -> ChampionRuneStat.builder()
-                        .championId(((Number) row.get("champion_id")).intValue())
+                        .championId(toInt(row.get("champion_id")))
                         .teamPosition((String) row.get("team_position"))
                         .season(season)
                         .tierGroup(tierGroupName)
                         .platformId(platformId)
                         .queueId(queueId)
                         .gameVersion(gameVersion)
-                        .primaryRuneId(((Number) row.get("primary_rune_id")).intValue())
+                        .primaryRuneId(toInt(row.get("primary_rune_id")))
                         .primaryRuneIds((String) row.get("primary_rune_ids"))
-                        .secondaryRuneId(((Number) row.get("secondary_rune_id")).intValue())
+                        .secondaryRuneId(toInt(row.get("secondary_rune_id")))
                         .secondaryRuneIds((String) row.get("secondary_rune_ids"))
-                        .statOffense(((Number) row.get("offense")).intValue())
-                        .statFlex(((Number) row.get("flex")).intValue())
-                        .statDefense(((Number) row.get("defense")).intValue())
-                        .games(((Number) row.get("games")).longValue())
-                        .wins(((Number) row.get("wins")).longValue())
+                        .statOffense(toInt(row.get("offense")))
+                        .statFlex(toInt(row.get("flex")))
+                        .statDefense(toInt(row.get("defense")))
+                        .games(toLong(row.get("games")))
+                        .wins(toLong(row.get("wins")))
                         .build())
                 .toList();
 
@@ -240,8 +240,8 @@ public class ChampionStatAggregationService implements TriggerChampionStatAggreg
     private void aggregateSpell(int season, int queueId, String tierGroupName,
                                 Set<String> tiers, String platformId, String gameVersion) {
         String sql = "SELECT ms.champion_id, ms.team_position, " +
-                "LEAST(ms.summoner1id, ms.summoner2id) AS spell1_id, " +
-                "GREATEST(ms.summoner1id, ms.summoner2id) AS spell2_id, " +
+                "LEAST(ms.summoner1_id, ms.summoner2_id) AS spell1_id, " +
+                "GREATEST(ms.summoner1_id, ms.summoner2_id) AS spell2_id, " +
                 "COUNT(*) AS games, " +
                 "SUM(CASE WHEN ms.win THEN 1 ELSE 0 END) AS wins " +
                 "FROM match_summoner ms " +
@@ -258,17 +258,17 @@ public class ChampionStatAggregationService implements TriggerChampionStatAggreg
 
         List<ChampionSpellStat> spellStats = rows.stream()
                 .map(row -> ChampionSpellStat.builder()
-                        .championId(((Number) row.get("champion_id")).intValue())
+                        .championId(toInt(row.get("champion_id")))
                         .teamPosition((String) row.get("team_position"))
                         .season(season)
                         .tierGroup(tierGroupName)
                         .platformId(platformId)
                         .queueId(queueId)
                         .gameVersion(gameVersion)
-                        .spell1Id(((Number) row.get("spell1_id")).intValue())
-                        .spell2Id(((Number) row.get("spell2_id")).intValue())
-                        .games(((Number) row.get("games")).longValue())
-                        .wins(((Number) row.get("wins")).longValue())
+                        .spell1Id(toInt(row.get("spell1_id")))
+                        .spell2Id(toInt(row.get("spell2_id")))
+                        .games(toLong(row.get("games")))
+                        .wins(toLong(row.get("wins")))
                         .build())
                 .toList();
 
@@ -531,16 +531,16 @@ public class ChampionStatAggregationService implements TriggerChampionStatAggreg
 
         List<ChampionMatchupStat> matchupStats = rows.stream()
                 .map(row -> ChampionMatchupStat.builder()
-                        .championId(((Number) row.get("champion_id")).intValue())
+                        .championId(toInt(row.get("champion_id")))
                         .teamPosition((String) row.get("team_position"))
                         .season(season)
                         .tierGroup(tierGroupName)
                         .platformId(platformId)
                         .queueId(queueId)
                         .gameVersion(gameVersion)
-                        .opponentChampionId(((Number) row.get("opponent_champion_id")).intValue())
-                        .games(((Number) row.get("games")).longValue())
-                        .wins(((Number) row.get("wins")).longValue())
+                        .opponentChampionId(toInt(row.get("opponent_champion_id")))
+                        .games(toLong(row.get("games")))
+                        .wins(toLong(row.get("wins")))
                         .avgKills(toBigDecimal(row.get("avg_kills")))
                         .avgDeaths(toBigDecimal(row.get("avg_deaths")))
                         .avgAssists(toBigDecimal(row.get("avg_assists")))
@@ -549,6 +549,14 @@ public class ChampionStatAggregationService implements TriggerChampionStatAggreg
                 .toList();
 
         championStatRepositoryPort.bulkSaveMatchupStats(matchupStats);
+    }
+
+    private int toInt(Object value) {
+        return value != null ? ((Number) value).intValue() : 0;
+    }
+
+    private long toLong(Object value) {
+        return value != null ? ((Number) value).longValue() : 0L;
     }
 
     private BigDecimal toBigDecimal(Object value) {

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/service/ChampionStatAggregationService.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/service/ChampionStatAggregationService.java
@@ -1,0 +1,592 @@
+package com.mmrtr.lol.infra.persistence.champion_stat.service;
+
+import com.mmrtr.lol.common.type.BuildType;
+import com.mmrtr.lol.common.type.ItemCategory;
+import com.mmrtr.lol.common.type.TierGroup;
+import com.mmrtr.lol.domain.champion_stat.domain.*;
+import com.mmrtr.lol.domain.champion_stat.repository.ChampionStatRepositoryPort;
+import com.mmrtr.lol.domain.champion_stat.service.usecase.TriggerChampionStatAggregationUseCase;
+import com.mmrtr.lol.infra.persistence.champion_stat.entity.ItemMetadataEntity;
+import com.mmrtr.lol.infra.persistence.champion_stat.repository.ItemMetadataJpaRepository;
+import com.mmrtr.lol.infra.redis.service.ChampionStatCacheService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChampionStatAggregationService implements TriggerChampionStatAggregationUseCase {
+
+    private final ChampionStatRepositoryPort championStatRepositoryPort;
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+    private final ItemMetadataJpaRepository itemMetadataJpaRepository;
+    private final ChampionStatCacheService championStatCacheService;
+
+    @Override
+    @Transactional
+    public void execute(int season, int queueId) {
+        log.info("챔피언 통계 집계 시작 - season: {}, queueId: {}", season, queueId);
+
+        // 1. 기존 집계 데이터 삭제
+        championStatRepositoryPort.deleteAllBySeasonAndQueueId(season, queueId);
+
+        // 2. 사용 가능한 차원 조합 조회
+        List<Map<String, Object>> dimensions = queryDistinctDimensions(season, queueId);
+        log.info("집계 대상 차원 조합 수: {}", dimensions.size());
+
+        // 3. 아이템 메타데이터 로드
+        Map<Integer, ItemMetadataEntity> itemMetadataMap = itemMetadataJpaRepository.findAll().stream()
+                .collect(Collectors.toMap(ItemMetadataEntity::getItemId, e -> e, (a, b) -> a));
+
+        // 4. 차원 조합별 루프
+        for (Map<String, Object> dim : dimensions) {
+            String platformId = (String) dim.get("platform_id");
+            String gameVersion = (String) dim.get("game_version");
+
+            for (TierGroup tierGroup : TierGroup.values()) {
+                try {
+                    aggregateForDimension(season, queueId, tierGroup, platformId, gameVersion, itemMetadataMap);
+                } catch (Exception e) {
+                    log.error("집계 실패 - tierGroup: {}, platform: {}, version: {}", tierGroup, platformId, gameVersion, e);
+                }
+            }
+        }
+
+        // 5. 캐시 무효화
+        championStatCacheService.evictAll();
+
+        log.info("챔피언 통계 집계 완료 - season: {}, queueId: {}", season, queueId);
+    }
+
+    private List<Map<String, Object>> queryDistinctDimensions(int season, int queueId) {
+        String sql = "SELECT DISTINCT m.platform_id, SUBSTRING(m.game_version FROM '^(\\d+\\.\\d+)') AS game_version " +
+                "FROM match m WHERE m.season = :season AND m.queue_id = :queueId " +
+                "AND SUBSTRING(m.game_version FROM '^(\\d+\\.\\d+)') IS NOT NULL";
+
+        return jdbcTemplate.queryForList(sql, new MapSqlParameterSource()
+                .addValue("season", season)
+                .addValue("queueId", queueId));
+    }
+
+    private void aggregateForDimension(int season, int queueId, TierGroup tierGroup,
+                                       String platformId, String gameVersion,
+                                       Map<Integer, ItemMetadataEntity> itemMetadataMap) {
+        Set<String> tiers = tierGroup.getIncludedTiers();
+        String tierGroupName = tierGroup.name();
+
+        // Summary 집계
+        aggregateSummary(season, queueId, tierGroupName, tiers, platformId, gameVersion);
+
+        // Rune 집계
+        aggregateRune(season, queueId, tierGroupName, tiers, platformId, gameVersion);
+
+        // Spell 집계
+        aggregateSpell(season, queueId, tierGroupName, tiers, platformId, gameVersion);
+
+        // Skill 집계
+        aggregateSkill(season, queueId, tierGroupName, tiers, platformId, gameVersion);
+
+        // Item 집계
+        aggregateItem(season, queueId, tierGroupName, tiers, platformId, gameVersion, itemMetadataMap);
+
+        // Matchup 집계
+        aggregateMatchup(season, queueId, tierGroupName, tiers, platformId, gameVersion);
+    }
+
+    private MapSqlParameterSource createBaseParams(int season, int queueId, Set<String> tiers, String platformId, String gameVersion) {
+        return new MapSqlParameterSource()
+                .addValue("season", season)
+                .addValue("queueId", queueId)
+                .addValue("tiers", tiers)
+                .addValue("platformId", platformId)
+                .addValue("gameVersion", gameVersion);
+    }
+
+    // === Summary 집계 ===
+    private void aggregateSummary(int season, int queueId, String tierGroupName,
+                                  Set<String> tiers, String platformId, String gameVersion) {
+        String sql = "SELECT ms.champion_id, ms.team_position, " +
+                "COUNT(*) AS total_games, " +
+                "SUM(CASE WHEN ms.win THEN 1 ELSE 0 END) AS wins, " +
+                "AVG(ms.kills) AS avg_kills, " +
+                "AVG(ms.deaths) AS avg_deaths, " +
+                "AVG(ms.assists) AS avg_assists, " +
+                "AVG(ms.total_minions_killed + ms.neutral_minions_killed) AS avg_cs, " +
+                "AVG(ms.gold_earned) AS avg_gold " +
+                "FROM match_summoner ms " +
+                "JOIN match m ON ms.match_id = m.match_id " +
+                "WHERE m.season = :season AND m.queue_id = :queueId " +
+                "AND m.platform_id = :platformId " +
+                "AND SUBSTRING(m.game_version FROM '^(\\d+\\.\\d+)') = :gameVersion " +
+                "AND ms.tier IN (:tiers) " +
+                "AND ms.team_position != '' " +
+                "GROUP BY ms.champion_id, ms.team_position";
+
+        MapSqlParameterSource params = createBaseParams(season, queueId, tiers, platformId, gameVersion);
+
+        List<Map<String, Object>> rows = jdbcTemplate.queryForList(sql, params);
+
+        // 밴 수 집계 (서브쿼리로 unnest 후 GROUP BY)
+        String banSql = "SELECT champion_id, COUNT(*) AS ban_count FROM (" +
+                "SELECT unnest(ARRAY[mt.champion1id, mt.champion2id, mt.champion3id, mt.champion4id, mt.champion5id]) AS champion_id " +
+                "FROM match_team mt " +
+                "JOIN match m ON mt.match_id = m.match_id " +
+                "WHERE m.season = :season AND m.queue_id = :queueId " +
+                "AND m.platform_id = :platformId " +
+                "AND SUBSTRING(m.game_version FROM '^(\\d+\\.\\d+)') = :gameVersion" +
+                ") AS ban_list WHERE champion_id > 0 GROUP BY champion_id";
+
+        Map<Integer, Long> banCounts;
+        try {
+            banCounts = jdbcTemplate.queryForList(banSql, params).stream()
+                    .collect(Collectors.toMap(
+                            r -> ((Number) r.get("champion_id")).intValue(),
+                            r -> ((Number) r.get("ban_count")).longValue(),
+                            Long::sum));
+        } catch (Exception e) {
+            log.error("밴 수 집계 실패, 0으로 대체 - platform: {}, version: {}", platformId, gameVersion, e);
+            banCounts = Map.of();
+        }
+
+        // 총 매치 수 조회
+        String totalMatchSql = "SELECT COUNT(DISTINCT m.match_id) AS total " +
+                "FROM match m WHERE m.season = :season AND m.queue_id = :queueId " +
+                "AND m.platform_id = :platformId " +
+                "AND SUBSTRING(m.game_version FROM '^(\\d+\\.\\d+)') = :gameVersion";
+
+        Long totalMatchesResult = jdbcTemplate.queryForObject(totalMatchSql, params, Long.class);
+        long totalMatches = totalMatchesResult != null ? totalMatchesResult : 0L;
+
+        Map<Integer, Long> finalBanCounts = banCounts;
+        List<ChampionStatSummary> summaries = rows.stream()
+                .map(row -> ChampionStatSummary.builder()
+                        .championId(((Number) row.get("champion_id")).intValue())
+                        .teamPosition((String) row.get("team_position"))
+                        .season(season)
+                        .tierGroup(tierGroupName)
+                        .platformId(platformId)
+                        .queueId(queueId)
+                        .gameVersion(gameVersion)
+                        .totalGames(((Number) row.get("total_games")).longValue())
+                        .wins(((Number) row.get("wins")).longValue())
+                        .totalBans(finalBanCounts.getOrDefault(((Number) row.get("champion_id")).intValue(), 0L))
+                        .totalMatchesInDimension(totalMatches)
+                        .avgKills(toBigDecimal(row.get("avg_kills")))
+                        .avgDeaths(toBigDecimal(row.get("avg_deaths")))
+                        .avgAssists(toBigDecimal(row.get("avg_assists")))
+                        .avgCs(toBigDecimal(row.get("avg_cs")))
+                        .avgGold(toBigDecimal(row.get("avg_gold")))
+                        .build())
+                .toList();
+
+        championStatRepositoryPort.bulkSaveSummaries(summaries);
+    }
+
+    // === Rune 집계 ===
+    private void aggregateRune(int season, int queueId, String tierGroupName,
+                               Set<String> tiers, String platformId, String gameVersion) {
+        String sql = "SELECT ms.champion_id, ms.team_position, " +
+                "ms.primary_rune_id, ms.primary_rune_ids, ms.secondary_rune_id, ms.secondary_rune_ids, " +
+                "ms.offense, ms.flex, ms.defense, " +
+                "COUNT(*) AS games, " +
+                "SUM(CASE WHEN ms.win THEN 1 ELSE 0 END) AS wins " +
+                "FROM match_summoner ms " +
+                "JOIN match m ON ms.match_id = m.match_id " +
+                "WHERE m.season = :season AND m.queue_id = :queueId " +
+                "AND m.platform_id = :platformId " +
+                "AND SUBSTRING(m.game_version FROM '^(\\d+\\.\\d+)') = :gameVersion " +
+                "AND ms.tier IN (:tiers) " +
+                "AND ms.team_position != '' " +
+                "GROUP BY ms.champion_id, ms.team_position, " +
+                "ms.primary_rune_id, ms.primary_rune_ids, ms.secondary_rune_id, ms.secondary_rune_ids, " +
+                "ms.offense, ms.flex, ms.defense";
+
+        List<Map<String, Object>> rows = jdbcTemplate.queryForList(sql,
+                createBaseParams(season, queueId, tiers, platformId, gameVersion));
+
+        List<ChampionRuneStat> runeStats = rows.stream()
+                .map(row -> ChampionRuneStat.builder()
+                        .championId(((Number) row.get("champion_id")).intValue())
+                        .teamPosition((String) row.get("team_position"))
+                        .season(season)
+                        .tierGroup(tierGroupName)
+                        .platformId(platformId)
+                        .queueId(queueId)
+                        .gameVersion(gameVersion)
+                        .primaryRuneId(((Number) row.get("primary_rune_id")).intValue())
+                        .primaryRuneIds((String) row.get("primary_rune_ids"))
+                        .secondaryRuneId(((Number) row.get("secondary_rune_id")).intValue())
+                        .secondaryRuneIds((String) row.get("secondary_rune_ids"))
+                        .statOffense(((Number) row.get("offense")).intValue())
+                        .statFlex(((Number) row.get("flex")).intValue())
+                        .statDefense(((Number) row.get("defense")).intValue())
+                        .games(((Number) row.get("games")).longValue())
+                        .wins(((Number) row.get("wins")).longValue())
+                        .build())
+                .toList();
+
+        championStatRepositoryPort.bulkSaveRuneStats(runeStats);
+    }
+
+    // === Spell 집계 ===
+    private void aggregateSpell(int season, int queueId, String tierGroupName,
+                                Set<String> tiers, String platformId, String gameVersion) {
+        String sql = "SELECT ms.champion_id, ms.team_position, " +
+                "LEAST(ms.summoner1id, ms.summoner2id) AS spell1_id, " +
+                "GREATEST(ms.summoner1id, ms.summoner2id) AS spell2_id, " +
+                "COUNT(*) AS games, " +
+                "SUM(CASE WHEN ms.win THEN 1 ELSE 0 END) AS wins " +
+                "FROM match_summoner ms " +
+                "JOIN match m ON ms.match_id = m.match_id " +
+                "WHERE m.season = :season AND m.queue_id = :queueId " +
+                "AND m.platform_id = :platformId " +
+                "AND SUBSTRING(m.game_version FROM '^(\\d+\\.\\d+)') = :gameVersion " +
+                "AND ms.tier IN (:tiers) " +
+                "AND ms.team_position != '' " +
+                "GROUP BY ms.champion_id, ms.team_position, spell1_id, spell2_id";
+
+        List<Map<String, Object>> rows = jdbcTemplate.queryForList(sql,
+                createBaseParams(season, queueId, tiers, platformId, gameVersion));
+
+        List<ChampionSpellStat> spellStats = rows.stream()
+                .map(row -> ChampionSpellStat.builder()
+                        .championId(((Number) row.get("champion_id")).intValue())
+                        .teamPosition((String) row.get("team_position"))
+                        .season(season)
+                        .tierGroup(tierGroupName)
+                        .platformId(platformId)
+                        .queueId(queueId)
+                        .gameVersion(gameVersion)
+                        .spell1Id(((Number) row.get("spell1_id")).intValue())
+                        .spell2Id(((Number) row.get("spell2_id")).intValue())
+                        .games(((Number) row.get("games")).longValue())
+                        .wins(((Number) row.get("wins")).longValue())
+                        .build())
+                .toList();
+
+        championStatRepositoryPort.bulkSaveSpellStats(spellStats);
+    }
+
+    // === Skill 집계 (챔피언별 배치 처리) ===
+    private void aggregateSkill(int season, int queueId, String tierGroupName,
+                                Set<String> tiers, String platformId, String gameVersion) {
+        MapSqlParameterSource baseParams = createBaseParams(season, queueId, tiers, platformId, gameVersion);
+
+        // 1. 해당 차원의 distinct champion_id 목록 조회
+        String championSql = "SELECT DISTINCT ms.champion_id FROM match_summoner ms " +
+                "JOIN match m ON ms.match_id = m.match_id " +
+                "WHERE m.season = :season AND m.queue_id = :queueId " +
+                "AND m.platform_id = :platformId " +
+                "AND SUBSTRING(m.game_version FROM '^(\\d+\\.\\d+)') = :gameVersion " +
+                "AND ms.tier IN (:tiers) AND ms.team_position != ''";
+
+        List<Integer> championIds = jdbcTemplate.queryForList(championSql, baseParams, Integer.class);
+
+        // 2. 챔피언별 skill_events 조회 후 처리
+        String sql = "SELECT ms.champion_id, ms.team_position, ms.match_id, ms.participant_id, ms.win, " +
+                "se.skill_slot, se.timestamp " +
+                "FROM match_summoner ms " +
+                "JOIN match m ON ms.match_id = m.match_id " +
+                "JOIN skill_events se ON se.match_id = ms.match_id AND se.participant_id = ms.participant_id " +
+                "WHERE m.season = :season AND m.queue_id = :queueId " +
+                "AND m.platform_id = :platformId " +
+                "AND SUBSTRING(m.game_version FROM '^(\\d+\\.\\d+)') = :gameVersion " +
+                "AND ms.tier IN (:tiers) " +
+                "AND ms.team_position != '' " +
+                "AND ms.champion_id = :championId " +
+                "AND se.level_up_type = 'NORMAL' " +
+                "ORDER BY ms.match_id, ms.participant_id, se.timestamp";
+
+        Map<String, SkillAggregation> skillAggMap = new HashMap<>();
+
+        for (int champId : championIds) {
+            MapSqlParameterSource params = createBaseParams(season, queueId, tiers, platformId, gameVersion)
+                    .addValue("championId", champId);
+
+            List<Map<String, Object>> rows = jdbcTemplate.queryForList(sql, params);
+
+            Map<String, List<Map<String, Object>>> grouped = rows.stream()
+                    .collect(Collectors.groupingBy(r ->
+                            r.get("match_id") + ":" + r.get("participant_id"), LinkedHashMap::new, Collectors.toList()));
+
+            for (List<Map<String, Object>> events : grouped.values()) {
+                if (events.isEmpty()) continue;
+
+                Map<String, Object> first = events.get(0);
+                int championId = ((Number) first.get("champion_id")).intValue();
+                String teamPosition = (String) first.get("team_position");
+                boolean win = (Boolean) first.get("win");
+
+                String skillOrder = events.stream()
+                        .limit(18)
+                        .map(e -> String.valueOf(((Number) e.get("skill_slot")).intValue()))
+                        .collect(Collectors.joining(","));
+
+                String skillPriority = calculateSkillPriority(events);
+
+                String key = championId + ":" + teamPosition + ":" + skillOrder;
+                skillAggMap.computeIfAbsent(key, k -> new SkillAggregation(championId, teamPosition, skillOrder, skillPriority));
+                SkillAggregation agg = skillAggMap.get(key);
+                agg.games++;
+                if (win) agg.wins++;
+            }
+        }
+
+        List<ChampionSkillStat> skillStats = skillAggMap.values().stream()
+                .map(agg -> ChampionSkillStat.builder()
+                        .championId(agg.championId)
+                        .teamPosition(agg.teamPosition)
+                        .season(season)
+                        .tierGroup(tierGroupName)
+                        .platformId(platformId)
+                        .queueId(queueId)
+                        .gameVersion(gameVersion)
+                        .skillOrder(agg.skillOrder)
+                        .skillPriority(agg.skillPriority)
+                        .games(agg.games)
+                        .wins(agg.wins)
+                        .build())
+                .toList();
+
+        championStatRepositoryPort.bulkSaveSkillStats(skillStats);
+    }
+
+    private String calculateSkillPriority(List<Map<String, Object>> events) {
+        // 레벨 1~9의 스킬 투자 순서를 기반으로 Q>W>E 우선순위 계산
+        int[] counts = new int[5]; // index 1=Q, 2=W, 3=E, 4=R
+        int limit = Math.min(events.size(), 9);
+        for (int i = 0; i < limit; i++) {
+            int slot = ((Number) events.get(i).get("skill_slot")).intValue();
+            if (slot >= 1 && slot <= 4) {
+                counts[slot]++;
+            }
+        }
+
+        // Q, W, E만 비교 (R 제외)
+        String[] skills = {"Q", "W", "E"};
+        int[] skillCounts = {counts[1], counts[2], counts[3]};
+
+        // 카운트 기준 정렬
+        Integer[] indices = {0, 1, 2};
+        Arrays.sort(indices, (a, b) -> skillCounts[b] - skillCounts[a]);
+
+        return skills[indices[0]] + ">" + skills[indices[1]] + ">" + skills[indices[2]];
+    }
+
+    // === Item 집계 (챔피언별 배치 처리) ===
+    private void aggregateItem(int season, int queueId, String tierGroupName,
+                               Set<String> tiers, String platformId, String gameVersion,
+                               Map<Integer, ItemMetadataEntity> itemMetadataMap) {
+        MapSqlParameterSource baseParams = createBaseParams(season, queueId, tiers, platformId, gameVersion);
+
+        // 1. 해당 차원의 distinct champion_id 목록 조회
+        String championSql = "SELECT DISTINCT ms.champion_id FROM match_summoner ms " +
+                "JOIN match m ON ms.match_id = m.match_id " +
+                "WHERE m.season = :season AND m.queue_id = :queueId " +
+                "AND m.platform_id = :platformId " +
+                "AND SUBSTRING(m.game_version FROM '^(\\d+\\.\\d+)') = :gameVersion " +
+                "AND ms.tier IN (:tiers) AND ms.team_position != ''";
+
+        List<Integer> championIds = jdbcTemplate.queryForList(championSql, baseParams, Integer.class);
+
+        // 2. 챔피언별 item_events 조회 (ITEM_PURCHASED만)
+        String sql = "SELECT ms.champion_id, ms.team_position, ms.match_id, ms.participant_id, ms.win, " +
+                "ie.item_id, ie.timestamp " +
+                "FROM match_summoner ms " +
+                "JOIN match m ON ms.match_id = m.match_id " +
+                "JOIN item_events ie ON ie.match_id = ms.match_id AND ie.participant_id = ms.participant_id " +
+                "WHERE m.season = :season AND m.queue_id = :queueId " +
+                "AND m.platform_id = :platformId " +
+                "AND SUBSTRING(m.game_version FROM '^(\\d+\\.\\d+)') = :gameVersion " +
+                "AND ms.tier IN (:tiers) " +
+                "AND ms.team_position != '' " +
+                "AND ms.champion_id = :championId " +
+                "AND ie.type = 'ITEM_PURCHASED' " +
+                "ORDER BY ms.match_id, ms.participant_id, ie.timestamp";
+
+        Map<String, ItemAggregation> itemAggMap = new HashMap<>();
+
+        for (int champId : championIds) {
+            MapSqlParameterSource params = createBaseParams(season, queueId, tiers, platformId, gameVersion)
+                    .addValue("championId", champId);
+
+            List<Map<String, Object>> rows = jdbcTemplate.queryForList(sql, params);
+
+            Map<String, List<Map<String, Object>>> grouped = rows.stream()
+                    .collect(Collectors.groupingBy(r ->
+                            r.get("match_id") + ":" + r.get("participant_id"), LinkedHashMap::new, Collectors.toList()));
+
+            for (List<Map<String, Object>> events : grouped.values()) {
+                if (events.isEmpty()) continue;
+
+                Map<String, Object> first = events.get(0);
+                int championId = ((Number) first.get("champion_id")).intValue();
+                String teamPosition = (String) first.get("team_position");
+                boolean win = (Boolean) first.get("win");
+
+                List<Integer> starterItems = new ArrayList<>();
+                List<Integer> bootsItems = new ArrayList<>();
+                List<Integer> coreItems = new ArrayList<>();
+
+                for (Map<String, Object> event : events) {
+                    int itemId = ((Number) event.get("item_id")).intValue();
+                    ItemMetadataEntity meta = itemMetadataMap.get(itemId);
+                    if (meta == null) continue;
+
+                    String category = meta.getItemCategory();
+                    if (ItemCategory.STARTER.name().equals(category) && starterItems.size() < 3) {
+                        starterItems.add(itemId);
+                    } else if (ItemCategory.BOOTS.name().equals(category) && bootsItems.isEmpty()) {
+                        bootsItems.add(itemId);
+                    } else if (ItemCategory.LEGENDARY.name().equals(category) && coreItems.size() < 3) {
+                        coreItems.add(itemId);
+                    }
+                }
+
+                // 스타터 빌드
+                if (!starterItems.isEmpty()) {
+                    Collections.sort(starterItems);
+                    String itemIds = starterItems.stream().map(String::valueOf).collect(Collectors.joining(","));
+                    String key = championId + ":" + teamPosition + ":" + BuildType.STARTER.name() + ":" + itemIds;
+                    itemAggMap.computeIfAbsent(key, k -> new ItemAggregation(championId, teamPosition, BuildType.STARTER.name(), itemIds));
+                    ItemAggregation agg = itemAggMap.get(key);
+                    agg.games++;
+                    if (win) agg.wins++;
+                }
+
+                // 부츠 빌드
+                if (!bootsItems.isEmpty()) {
+                    String itemIds = String.valueOf(bootsItems.get(0));
+                    String key = championId + ":" + teamPosition + ":" + BuildType.BOOTS.name() + ":" + itemIds;
+                    itemAggMap.computeIfAbsent(key, k -> new ItemAggregation(championId, teamPosition, BuildType.BOOTS.name(), itemIds));
+                    ItemAggregation agg = itemAggMap.get(key);
+                    agg.games++;
+                    if (win) agg.wins++;
+                }
+
+                // 코어 빌드
+                if (!coreItems.isEmpty()) {
+                    Collections.sort(coreItems);
+                    String itemIds = coreItems.stream().map(String::valueOf).collect(Collectors.joining(","));
+                    String key = championId + ":" + teamPosition + ":" + BuildType.CORE.name() + ":" + itemIds;
+                    itemAggMap.computeIfAbsent(key, k -> new ItemAggregation(championId, teamPosition, BuildType.CORE.name(), itemIds));
+                    ItemAggregation agg = itemAggMap.get(key);
+                    agg.games++;
+                    if (win) agg.wins++;
+                }
+            }
+        }
+
+        List<ChampionItemStat> itemStats = itemAggMap.values().stream()
+                .map(agg -> ChampionItemStat.builder()
+                        .championId(agg.championId)
+                        .teamPosition(agg.teamPosition)
+                        .season(season)
+                        .tierGroup(tierGroupName)
+                        .platformId(platformId)
+                        .queueId(queueId)
+                        .gameVersion(gameVersion)
+                        .buildType(agg.buildType)
+                        .itemIds(agg.itemIds)
+                        .games(agg.games)
+                        .wins(agg.wins)
+                        .build())
+                .toList();
+
+        championStatRepositoryPort.bulkSaveItemStats(itemStats);
+    }
+
+    // === Matchup 집계 ===
+    private void aggregateMatchup(int season, int queueId, String tierGroupName,
+                                  Set<String> tiers, String platformId, String gameVersion) {
+        String sql = "SELECT ms1.champion_id, ms1.team_position, ms2.champion_id AS opponent_champion_id, " +
+                "COUNT(*) AS games, " +
+                "SUM(CASE WHEN ms1.win THEN 1 ELSE 0 END) AS wins, " +
+                "AVG(ms1.kills) AS avg_kills, " +
+                "AVG(ms1.deaths) AS avg_deaths, " +
+                "AVG(ms1.assists) AS avg_assists, " +
+                "AVG(ms1.gold_earned - ms2.gold_earned) AS avg_gold_diff " +
+                "FROM match_summoner ms1 " +
+                "JOIN match_summoner ms2 ON ms1.match_id = ms2.match_id " +
+                "AND ms1.team_position = ms2.team_position " +
+                "AND ms1.team_id != ms2.team_id " +
+                "JOIN match m ON ms1.match_id = m.match_id " +
+                "WHERE m.season = :season AND m.queue_id = :queueId " +
+                "AND m.platform_id = :platformId " +
+                "AND SUBSTRING(m.game_version FROM '^(\\d+\\.\\d+)') = :gameVersion " +
+                "AND ms1.tier IN (:tiers) " +
+                "AND ms1.team_position != '' " +
+                "GROUP BY ms1.champion_id, ms1.team_position, ms2.champion_id";
+
+        List<Map<String, Object>> rows = jdbcTemplate.queryForList(sql,
+                createBaseParams(season, queueId, tiers, platformId, gameVersion));
+
+        List<ChampionMatchupStat> matchupStats = rows.stream()
+                .map(row -> ChampionMatchupStat.builder()
+                        .championId(((Number) row.get("champion_id")).intValue())
+                        .teamPosition((String) row.get("team_position"))
+                        .season(season)
+                        .tierGroup(tierGroupName)
+                        .platformId(platformId)
+                        .queueId(queueId)
+                        .gameVersion(gameVersion)
+                        .opponentChampionId(((Number) row.get("opponent_champion_id")).intValue())
+                        .games(((Number) row.get("games")).longValue())
+                        .wins(((Number) row.get("wins")).longValue())
+                        .avgKills(toBigDecimal(row.get("avg_kills")))
+                        .avgDeaths(toBigDecimal(row.get("avg_deaths")))
+                        .avgAssists(toBigDecimal(row.get("avg_assists")))
+                        .avgGoldDiff(toBigDecimal(row.get("avg_gold_diff")))
+                        .build())
+                .toList();
+
+        championStatRepositoryPort.bulkSaveMatchupStats(matchupStats);
+    }
+
+    private BigDecimal toBigDecimal(Object value) {
+        if (value == null) return BigDecimal.ZERO;
+        if (value instanceof BigDecimal) return (BigDecimal) value;
+        return BigDecimal.valueOf(((Number) value).doubleValue());
+    }
+
+    // 내부 집계 헬퍼 클래스
+    private static class SkillAggregation {
+        final int championId;
+        final String teamPosition;
+        final String skillOrder;
+        final String skillPriority;
+        long games;
+        long wins;
+
+        SkillAggregation(int championId, String teamPosition, String skillOrder, String skillPriority) {
+            this.championId = championId;
+            this.teamPosition = teamPosition;
+            this.skillOrder = skillOrder;
+            this.skillPriority = skillPriority;
+        }
+    }
+
+    private static class ItemAggregation {
+        final int championId;
+        final String teamPosition;
+        final String buildType;
+        final String itemIds;
+        long games;
+        long wins;
+
+        ItemAggregation(int championId, String teamPosition, String buildType, String itemIds) {
+            this.championId = championId;
+            this.teamPosition = teamPosition;
+            this.buildType = buildType;
+            this.itemIds = itemIds;
+        }
+    }
+}

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/service/ChampionStatQueryService.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/service/ChampionStatQueryService.java
@@ -1,0 +1,95 @@
+package com.mmrtr.lol.infra.persistence.champion_stat.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mmrtr.lol.domain.champion_stat.domain.*;
+import com.mmrtr.lol.domain.champion_stat.repository.ChampionStatRepositoryPort;
+import com.mmrtr.lol.domain.champion_stat.service.usecase.ChampionStatQueryUseCase;
+import com.mmrtr.lol.infra.redis.service.ChampionStatCacheService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChampionStatQueryService implements ChampionStatQueryUseCase {
+
+    private final ChampionStatRepositoryPort championStatRepositoryPort;
+    private final ChampionStatCacheService championStatCacheService;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public List<ChampionStatSummary> getSummaries(int championId, String position, int season, String tierGroup, String platformId, int queueId, String patch) {
+        String cacheKey = championStatCacheService.buildCacheKey("summary", championId, position, season, tierGroup, platformId, queueId, patch);
+        return getWithCache(cacheKey,
+                new TypeReference<>() {},
+                () -> championStatRepositoryPort.findSummaries(championId, position, season, tierGroup, platformId, queueId, patch));
+    }
+
+    @Override
+    public List<ChampionRuneStat> getRuneStats(int championId, String position, int season, String tierGroup, String platformId, int queueId, String patch) {
+        String cacheKey = championStatCacheService.buildCacheKey("rune", championId, position, season, tierGroup, platformId, queueId, patch);
+        return getWithCache(cacheKey,
+                new TypeReference<>() {},
+                () -> championStatRepositoryPort.findRuneStats(championId, position, season, tierGroup, platformId, queueId, patch));
+    }
+
+    @Override
+    public List<ChampionSpellStat> getSpellStats(int championId, String position, int season, String tierGroup, String platformId, int queueId, String patch) {
+        String cacheKey = championStatCacheService.buildCacheKey("spell", championId, position, season, tierGroup, platformId, queueId, patch);
+        return getWithCache(cacheKey,
+                new TypeReference<>() {},
+                () -> championStatRepositoryPort.findSpellStats(championId, position, season, tierGroup, platformId, queueId, patch));
+    }
+
+    @Override
+    public List<ChampionSkillStat> getSkillStats(int championId, String position, int season, String tierGroup, String platformId, int queueId, String patch) {
+        String cacheKey = championStatCacheService.buildCacheKey("skill", championId, position, season, tierGroup, platformId, queueId, patch);
+        return getWithCache(cacheKey,
+                new TypeReference<>() {},
+                () -> championStatRepositoryPort.findSkillStats(championId, position, season, tierGroup, platformId, queueId, patch));
+    }
+
+    @Override
+    public List<ChampionItemStat> getItemStats(int championId, String position, int season, String tierGroup, String platformId, int queueId, String patch) {
+        String cacheKey = championStatCacheService.buildCacheKey("item", championId, position, season, tierGroup, platformId, queueId, patch);
+        return getWithCache(cacheKey,
+                new TypeReference<>() {},
+                () -> championStatRepositoryPort.findItemStats(championId, position, season, tierGroup, platformId, queueId, patch));
+    }
+
+    @Override
+    public List<ChampionMatchupStat> getMatchupStats(int championId, String position, int season, String tierGroup, String platformId, int queueId, String patch) {
+        String cacheKey = championStatCacheService.buildCacheKey("matchup", championId, position, season, tierGroup, platformId, queueId, patch);
+        return getWithCache(cacheKey,
+                new TypeReference<>() {},
+                () -> championStatRepositoryPort.findMatchupStats(championId, position, season, tierGroup, platformId, queueId, patch));
+    }
+
+    private <T> List<T> getWithCache(String cacheKey, TypeReference<List<T>> typeRef, Supplier<List<T>> dbFallback) {
+        Optional<String> cached = championStatCacheService.get(cacheKey);
+        if (cached.isPresent()) {
+            try {
+                return objectMapper.readValue(cached.get(), typeRef);
+            } catch (JsonProcessingException e) {
+                log.warn("캐시 역직렬화 실패, DB 조회로 대체 - key: {}", cacheKey, e);
+            }
+        }
+
+        List<T> result = dbFallback.get();
+
+        try {
+            championStatCacheService.put(cacheKey, objectMapper.writeValueAsString(result));
+        } catch (JsonProcessingException e) {
+            log.warn("캐시 직렬화 실패 - key: {}", cacheKey, e);
+        }
+
+        return result;
+    }
+}

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/service/ItemMetadataService.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/champion_stat/service/ItemMetadataService.java
@@ -1,0 +1,60 @@
+package com.mmrtr.lol.infra.persistence.champion_stat.service;
+
+import com.mmrtr.lol.domain.champion_stat.domain.ItemMetadata;
+import com.mmrtr.lol.domain.champion_stat.service.usecase.ItemMetadataUseCase;
+import com.mmrtr.lol.infra.persistence.champion_stat.entity.ItemMetadataEntity;
+import com.mmrtr.lol.infra.persistence.champion_stat.repository.ItemMetadataJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ItemMetadataService implements ItemMetadataUseCase {
+
+    private final ItemMetadataJpaRepository itemMetadataJpaRepository;
+
+    @Override
+    public ItemMetadata save(ItemMetadata itemMetadata) {
+        ItemMetadataEntity entity = ItemMetadataEntity.builder()
+                .itemId(itemMetadata.getItemId())
+                .itemName(itemMetadata.getItemName())
+                .itemCategory(itemMetadata.getItemCategory())
+                .gameVersion(itemMetadata.getGameVersion())
+                .build();
+        ItemMetadataEntity saved = itemMetadataJpaRepository.save(entity);
+        return toDomain(saved);
+    }
+
+    @Override
+    public List<ItemMetadata> saveAll(List<ItemMetadata> metadataList) {
+        List<ItemMetadataEntity> entities = metadataList.stream()
+                .map(m -> ItemMetadataEntity.builder()
+                        .itemId(m.getItemId())
+                        .itemName(m.getItemName())
+                        .itemCategory(m.getItemCategory())
+                        .gameVersion(m.getGameVersion())
+                        .build())
+                .toList();
+        return itemMetadataJpaRepository.saveAll(entities).stream()
+                .map(this::toDomain)
+                .toList();
+    }
+
+    @Override
+    public List<ItemMetadata> findAll() {
+        return itemMetadataJpaRepository.findAll().stream()
+                .map(this::toDomain)
+                .toList();
+    }
+
+    private ItemMetadata toDomain(ItemMetadataEntity entity) {
+        return ItemMetadata.builder()
+                .itemId(entity.getItemId())
+                .itemName(entity.getItemName())
+                .itemCategory(entity.getItemCategory())
+                .gameVersion(entity.getGameVersion())
+                .build();
+    }
+}

--- a/infra/persistence/src/main/resources/application-persistence.yml
+++ b/infra/persistence/src/main/resources/application-persistence.yml
@@ -16,22 +16,21 @@ spring:
     activate:
       on-profile: local
   datasource:
-#    url: jdbc:postgresql://localhost:5432/postgres
-#    driver-class-name: org.postgresql.Driver
-#    username: postgres
-#    password: 1234
     url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
     driver-class-name: org.postgresql.Driver
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     show-sql: false
     properties:
       hibernate:
         format_sql: true
         use_sql_comments: true
+  flyway:
+    enabled: true
+    baseline-on-migrate: false
 
 ---
 spring:
@@ -52,6 +51,10 @@ spring:
         format_sql: false
         use_sql_comments: false
         generate_statistics: false
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+    baseline-version: 7
 
 ---
 spring:
@@ -65,5 +68,8 @@ spring:
     password: postgres
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     show-sql: false
+  flyway:
+    enabled: true
+    baseline-on-migrate: false

--- a/infra/persistence/src/main/resources/application-persistence.yml
+++ b/infra/persistence/src/main/resources/application-persistence.yml
@@ -30,7 +30,8 @@ spring:
         use_sql_comments: true
   flyway:
     enabled: true
-    baseline-on-migrate: false
+    baseline-on-migrate: true
+    baseline-version: 7
 
 ---
 spring:
@@ -72,4 +73,5 @@ spring:
     show-sql: false
   flyway:
     enabled: true
-    baseline-on-migrate: false
+    baseline-on-migrate: true
+    baseline-version: 7

--- a/infra/redis/src/main/java/com/mmrtr/lol/infra/redis/service/ChampionStatCacheService.java
+++ b/infra/redis/src/main/java/com/mmrtr/lol/infra/redis/service/ChampionStatCacheService.java
@@ -1,0 +1,45 @@
+package com.mmrtr.lol.infra.redis.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChampionStatCacheService {
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    private static final Duration CACHE_TTL = Duration.ofHours(1);
+    private static final String KEY_PREFIX = "champion_stat:";
+
+    public String buildCacheKey(String type, int championId, String position, int season,
+                                String tierGroup, String platform, int queueId, String patch) {
+        return KEY_PREFIX + type + ":" + championId + ":" + position + ":" + season + ":"
+                + tierGroup + ":" + platform + ":" + queueId + ":" + patch;
+    }
+
+    public Optional<String> get(String cacheKey) {
+        String value = stringRedisTemplate.opsForValue().get(cacheKey);
+        return Optional.ofNullable(value);
+    }
+
+    public void put(String cacheKey, String jsonValue) {
+        stringRedisTemplate.opsForValue().set(cacheKey, jsonValue, CACHE_TTL);
+    }
+
+    public void evictAll() {
+        Set<String> keys = stringRedisTemplate.keys(KEY_PREFIX + "*");
+        if (keys != null && !keys.isEmpty()) {
+            stringRedisTemplate.delete(keys);
+            log.info("챔피언 통계 캐시 무효화 완료 - {} 건", keys.size());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Git 서브모듈(`lol-db-schema`)을 통한 Flyway DB 마이그레이션 구성 및 DDL auto를 `update`에서 `validate`로 변경
- 챔피언 통계 도메인/API/Persistence/Redis 캐싱 계층 구현 (아이템, 매치업, 룬, 스킬, 스펠, 요약 통계)
- ClickHouse 분석 DB docker-compose 추가 및 공유 enum 타입 추가 (BuildType, ItemCategory, Position, TierGroup)

## Test plan
- [x] `./gradlew build` 전체 모듈 빌드 확인
- [x] Flyway 마이그레이션이 local/prod 프로파일에서 정상 동작하는지 확인
- [x] 챔피언 통계 API 엔드포인트 호출 테스트
- [x] Redis 캐싱 서비스 동작 확인
- [x] ClickHouse 컨테이너 정상 기동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)