### PR TITLE
fix: private 서브모듈 checkout을 위한 PAT 토큰 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
+          token: ${{ secrets.SUBMODULE_PAT }}
 
       - uses: actions/setup-java@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           submodules: recursive
+          token: ${{ secrets.SUBMODULE_PAT }}
 
       - name: Extract version and SHA
         id: version


### PR DESCRIPTION
## Summary
- CI/Deploy 워크플로우에서 private 서브모듈(`lol-db-schema`) clone 실패 수정
- `actions/checkout`에 `SUBMODULE_PAT` Secret 토큰을 전달하여 private 리포지토리 접근 허용

## 필요한 설정
- GitHub Secret `SUBMODULE_PAT` 등록 필요 (Fine-grained PAT, `lol-db-schema` Contents: Read 권한)

## Test plan
- [ ] `SUBMODULE_PAT` Secret 등록 후 CI 워크플로우 재실행
- [ ] 서브모듈 checkout 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)