### PR TITLE
feat: add JDK 21 virtual thread support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,24 @@
+# ===========================================
+# LOL Repository - Local 개발 환경 변수
+# ===========================================
+# 사용법: 이 파일을 .env로 복사 후 값을 수정하세요
+#   cp .env.example .env
+# ===========================================
+
+# --- Riot Games API ---
+RIOT_API_KEY=your-riot-api-key-here
+
+# --- PostgreSQL ---
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=postgres
+DB_USERNAME=postgres
+DB_PASSWORD=1234
+
+# --- Spring ---
+SPRING_PROFILES_ACTIVE=local
+
+# --- Monitoring (WSL Ubuntu) ---
+# WSL Ubuntu IP 예시:
+#   hostname -I | awk '{print $1}'
+PROMETHEUS_SCRAPE_HOST_IP=172.20.80.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
           cache: gradle
 
       - name: Build

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -14,6 +14,9 @@ spring:
     time-zone: Asia/Seoul
   lifecycle:
     timeout-per-shutdown-phase: 30s
+  threads:
+    virtual:
+      enabled: ${LOL_VT_ENABLED:true}
 
 server:
   shutdown: graceful
@@ -22,9 +25,14 @@ management:
   endpoints:
     web:
       exposure:
-        include: health, info, metrics, prometheus
+        include: ${MANAGEMENT_ENDPOINTS_EXPOSURE_INCLUDE:health,info,metrics,prometheus,threaddump}
   endpoint:
     health:
       show-details: when_authorized
       probes:
         enabled: true
+
+lol:
+  vt:
+    executors:
+      enabled: ${LOL_VT_EXECUTORS_ENABLED:${LOL_VT_ENABLED:true}}

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'java-library'
-    id 'org.springframework.boot' version '3.3.1' apply(false)
+    id 'org.springframework.boot' version '3.5.9' apply(false)
     id 'io.spring.dependency-management' version '1.1.5' apply(false)
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ subprojects {
 
     java {
         toolchain {
-            languageVersion = JavaLanguageVersion.of(17)
+            languageVersion = JavaLanguageVersion.of(21)
         }
     }
 
@@ -54,10 +54,13 @@ subprojects {
         enabled = false
     }
 
+    tasks.withType(JavaCompile).configureEach {
+        options.compilerArgs += ['-parameters']
+    }
+
     bootRun {
         String activeProfile = System.properties['spring.profiles.active']
         systemProperty "spring.profiles.active", activeProfile
     }
 
 }
-

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 
 # Stage 1: 빌드
-FROM eclipse-temurin:17-jdk AS build
+FROM eclipse-temurin:21-jdk AS build
 WORKDIR /app
 
 # Gradle Wrapper 복사 및 실행 권한 부여
@@ -20,7 +20,7 @@ COPY lol-db-schema lol-db-schema
 RUN ./gradlew :app:bootJar -x test --no-daemon
 
 # Stage 2: 런타임
-FROM eclipse-temurin:17-jre
+FROM eclipse-temurin:21-jre
 WORKDIR /app
 
 # 환경변수 선언
@@ -31,6 +31,7 @@ COPY --from=build /app/app/build/libs/*.jar app.jar
 
 # JVM 컨테이너 최적화 옵션
 ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:InitialRAMPercentage=50.0"
+ENV JVM_DIAGNOSTIC_OPTS=""
 
 # 포트 노출
 EXPOSE 8080
@@ -40,4 +41,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
     CMD curl -f http://localhost:8080/actuator/health || exit 1
 
 # 쉘 형식으로 변경하여 환경 변수 확장 지원
-ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -Dspring.profiles.active=${SPRING_PROFILES_ACTIVE} -jar app.jar"]
+ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS $JVM_DIAGNOSTIC_OPTS -Dspring.profiles.active=${SPRING_PROFILES_ACTIVE} -jar app.jar"]

--- a/docs/jdk21-virtual-thread-analysis.md
+++ b/docs/jdk21-virtual-thread-analysis.md
@@ -1,0 +1,209 @@
+# JDK 21 + Virtual Thread 도입 타당성 분석
+
+> 작성일: 2026-03-13
+
+## 1. 현재 동시성 아키텍처
+
+LOL Repository는 Java 17 + Spring Boot 3.3.1 기반으로, RIOT API 호출과 DB 배치 작업을
+**CompletableFuture + 4개 커스텀 ThreadPoolTaskExecutor** 및 **RabbitMQ 리스너 26개 컨슈머 스레드**로 처리하고 있다.
+
+### 스레드 풀 구성
+
+| 구성 요소 | 스레드 수 | 용도 |
+|-----------|----------|------|
+| `requestExecutor` | core=20, max=40, queue=100 | 일반 RIOT API 호출 |
+| `riotApiExecutor` | core=20, max=40, queue=40 | MatchListener용 API 호출 |
+| `matchFindExecutor` | core=5, max=10, queue=20 | 매치 ID 검색 |
+| `timelineSaveExecutor` | core=10, max=10, queue=0 (CallerRunsPolicy) | DB 병렬 벌크 저장 |
+| RabbitMQ 컨슈머 | 1 + 5 + 20 = 26 | 메시지 처리 |
+| Tomcat | ~200 (기본값) | HTTP 요청 |
+| **추정 총 플랫폼 스레드** | **~300-400** | |
+
+### 주요 블로킹 패턴
+
+- `.join()` 15곳+ — CompletableFuture 결과 대기
+- `globalApiRateLimiter.acquire(1)` — Redisson RateLimiter 블로킹
+- `RLock.tryLock()` — 분산 락 대기
+- `RetryInterceptor` — `Thread.sleep(2000)` 2초 backoff
+- 동기 JDBC 배치 작업 — pgjdbc 블로킹 I/O
+
+---
+
+## 2. Virtual Thread 이점 분석
+
+### HIGH 이점
+
+| 패턴 | 현재 상태 | Virtual Thread 적용 시 |
+|------|----------|----------------------|
+| **RIOT API 호출** (RiotApiService 11개 메서드) | `supplyAsync()` + executor로 플랫폼 스레드 점유하며 HTTP I/O 대기 | JDK 21의 `java.net.http.HttpClient`는 VT 친화적. carrier thread가 I/O 대기 중 해제됨 |
+| **MatchListener** (20 컨슈머) | 각각 rate limiter 블로킹 + HTTP + `.join()` | 20개 플랫폼 스레드 → VT로 전환, carrier thread 재활용 가능 |
+| **RetryInterceptor** 2초 backoff | `Thread.sleep(2000)`으로 플랫폼 스레드 낭비 | VT의 `Thread.sleep()`은 carrier에서 즉시 unmount |
+
+### MODERATE 이점
+
+| 패턴 | 비고 |
+|------|------|
+| **SummonerRenewalService** 복합 Future 체인 | `.join()` 5곳에서 블로킹하지만 컨슈머 1개라 절대적 이점은 작음 |
+| **Tomcat 요청 스레드** | `SummonerService`, `SpectatorService` 등에서 `.join()` 호출 시 carrier 해제 |
+
+### 이점 없음 / 위험
+
+| 패턴 | 이유 |
+|------|------|
+| **TimeLineService 병렬 벌크 저장** (10개 Future) | pgjdbc의 `synchronized` 블록 → carrier thread **핀닝** 발생, 오히려 악화 가능 |
+| **MatchService.addAllMatch()** | 단일 `@Transactional`, 순차 실행 → 병렬성 없음 |
+| **SummonerRankingScheduler** | 단일 스레드 스케줄 작업 → 이점 없음 |
+| **RedisLockHandler.acquireLock()** | `tryLock(0, ...)` 이미 논블로킹 |
+
+---
+
+## 3. 핵심 호환성 이슈
+
+### 3.1 pgjdbc `synchronized` 핀닝 (위험도: HIGH)
+
+- PostgreSQL JDBC 드라이버가 `PgConnection`, `QueryExecutorImpl` 등에서 `synchronized` 사용
+- VT가 `synchronized` 블록 안에서 I/O 블로킹 시 carrier thread 핀닝
+- **`timelineSaveExecutor`를 VT로 전환하면 안 됨**
+
+### 3.2 HikariCP 커넥션 풀 고갈 (위험도: MODERATE)
+
+- 현재 max 15개 커넥션
+- VT는 무제한 생성 가능 → 커넥션 풀 경합 폭증 위험
+- DB 접근 경로에 `Semaphore` 등 동시성 제한 필요
+
+### 3.3 Redisson/Netty 핀닝 (위험도: MODERATE)
+
+- Redisson 3.46.0은 대부분 `ReentrantLock` 전환 완료
+- 단, Netty 내부 `synchronized` 잔존 → `acquire(1)` 블로킹 시 짧은 핀닝 가능
+- `-Djdk.tracePinnedThreads=short`로 테스트 필요
+
+### 3.4 Spring Boot 3.3.1 호환성 (위험도: LOW)
+
+- Spring Boot 3.2+에서 `spring.threads.virtual.enabled=true` 공식 지원
+- **Spring Boot 업그레이드 불필요** — 현재 3.3.1로 충분
+
+---
+
+## 4. 최종 결론
+
+### JDK 21 업그레이드: 강력 추천 (VT 무관)
+
+- 더 나은 GC 성능 (G1/ZGC 개선)
+- Pattern matching, Record patterns, Sequenced Collections 등 언어 기능
+- 2029년+까지 LTS 지원
+
+### Virtual Thread 적용: 제한적 이점 (리소스 효율성 개선)
+
+> **이 애플리케이션의 처리량은 스레드 풀이 아닌 RIOT API Rate Limiter(20 req/sec)에 의해 제한된다.**
+> Virtual Thread는 이 병목을 해결하지 못한다.
+
+**실질적 이점:**
+- ~80-100개 플랫폼 스레드가 I/O 대기 중 낭비되는 것 방지 (리소스 효율성)
+- 스레드 풀 사이징 튜닝 부담 감소
+- Rate Limit이 향후 증가할 경우 스레드 풀 병목 없이 자연스럽게 확장
+
+**한계:**
+- 현재 워크로드에서 **처리량(throughput) 향상은 없음** — rate limiter가 병목
+- DB 작업 경로에는 적용 불가 (pgjdbc 핀닝)
+- Redisson 블로킹 호출에서 핀닝 가능성 존재
+
+---
+
+## 5. 권장 마이그레이션 단계
+
+### Phase 0: JDK 21 업그레이드 (Virtual Thread 없이)
+
+| 파일 | 변경 내용 |
+|------|----------|
+| `build.gradle` | `JavaLanguageVersion.of(17)` → `of(21)` |
+| `docker/Dockerfile` | `eclipse-temurin:17-jdk/jre` → `21-jdk/jre`, JVM 핀닝 진단 플래그 추가 |
+| `.github/workflows/ci.yml` | `java-version: 17` → `21` |
+
+검증: `./gradlew build` 성공, `./gradlew :app:bootRun` 정상 기동
+
+### Phase 1: Tomcat Virtual Thread 활성화
+
+| 파일 | 변경 내용 |
+|------|----------|
+| `app/src/main/resources/application.yml` | `spring.threads.virtual.enabled: true` 추가 |
+
+효과: API 엔드포인트(SummonerService 등)의 `.join()` 호출이 carrier thread 미점유
+
+### Phase 2: RIOT API Executor를 Virtual Thread로 전환
+
+| 파일 | 변경 내용 |
+|------|----------|
+| `infra/riot-client/.../config/AsyncConfig.java` | `requestExecutor`, `matchFindExecutor`, `riotApiExecutor` 3개를 `Executors.newVirtualThreadPerTaskExecutor()`로 교체. **`timelineSaveExecutor`는 기존 유지** (DB 핀닝 방지) |
+
+### Phase 3: RabbitMQ 리스너 Virtual Thread 전환
+
+| 파일 | 변경 내용 |
+|------|----------|
+| `infra/rabbitmq/.../config/RabbitMqConfig.java` | 리스너 컨테이너 팩토리에 VT task executor 설정 |
+
+모니터링: `-Djdk.tracePinnedThreads=short`로 핀닝 확인
+
+### Phase 4 (보류): StructuredTaskScope 적용
+
+JDK 25 LTS에서 정식 출시 시 CompletableFuture 체인 단순화 검토
+
+---
+
+## 6. Before/After 예상 스레드 리소스
+
+| 구성 요소 | Before (플랫폼 스레드) | After (VT 적용) |
+|-----------|----------------------|-----------------|
+| `requestExecutor` | 20~40개 | 0개 (VT executor) |
+| `riotApiExecutor` | 20~40개 | 0개 (VT executor) |
+| `matchFindExecutor` | 5~10개 | 0개 (VT executor) |
+| `timelineSaveExecutor` | 10개 | 10개 유지 (DB 핀닝) |
+| RabbitMQ 컨슈머 | 26개 | 0개 (VT 전환) |
+| Tomcat | ~200개 | 0개 (VT 전환) |
+| **합계** | **~280-330개** | **~10개 + carrier(CPU 코어 수)** |
+
+---
+
+## 7. 검증 및 모니터링 방법
+
+### 검증 체크리스트
+
+1. **Phase 0**: `./gradlew build` 성공, `./gradlew :app:bootRun` 정상 기동
+2. **Phase 1-3**: `-Djdk.tracePinnedThreads=short` JVM 플래그로 핀닝 모니터링
+3. **스레드 덤프 비교**: 업그레이드 전후 `jstack` 또는 Actuator `/threaddump`로 플랫폼 스레드 수 비교
+4. **부하 테스트**: RabbitMQ에 메시지 대량 투입 후 처리량/응답시간 비교
+5. **Hikari 모니터링**: Actuator의 HikariCP 메트릭으로 커넥션 풀 사용량 확인
+
+### 모니터링 도구
+
+1. **VisualVM / JConsole** (로컬 개발): 실시간 스레드 수, 이름, CPU 그래프 확인
+2. **Actuator 메트릭** (간편 비교):
+   - `GET /actuator/metrics/jvm.threads.live` — 활성 스레드 수
+   - `GET /actuator/metrics/jvm.threads.peak` — 피크 스레드 수
+3. **jstack 스레드 덤프** (직관적 비교):
+   - Before: `Request Thread-*`, `Riot API Thread-*`, `MatchFind Thread-*` 등 이름으로 각 풀 확인
+   - After: 해당 이름 사라지고 `VirtualThread` 형태로 전환 확인
+4. **Prometheus + Grafana** (운영 환경): `jvm_threads_live_threads` 메트릭 시계열 대시보드
+5. **핀닝 모니터링**: `-Djdk.tracePinnedThreads=short` JVM 플래그로 핀닝 스택트레이스 출력
+
+### 모니터링 환경 실행
+
+```bash
+# 1. 인프라 실행 (기존)
+docker compose -f docker/docker-compose.yml up -d
+
+# 2. 모니터링 실행
+export PROMETHEUS_SCRAPE_HOST_IP="$(hostname -I | awk '{print $1}')"
+docker compose -f docker/monitoring/docker-compose.monitoring.yml up -d
+
+# 3. 앱 실행
+./gradlew :app:bootRun -Dspring.profiles.active=local
+
+# 4. 대시보드 확인
+# Grafana: http://localhost:3010 (admin/admin)
+# Prometheus: http://localhost:9090
+# Targets: http://localhost:9090/targets
+```
+
+WSL 우분투에서는 `host.docker.internal` 대신 `PROMETHEUS_SCRAPE_HOST_IP`에
+현재 WSL 배포판 IP를 넣고, Prometheus가 `wsl-app-host:8111/actuator/prometheus`를 읽는다.
+WSL 재시작이나 네트워크 변경 후에는 IP가 바뀔 수 있으므로 값을 다시 갱신해야 한다.

--- a/docs/vt-comparison-test-guide.md
+++ b/docs/vt-comparison-test-guide.md
@@ -1,0 +1,165 @@
+# VT 전후 비교 테스트 가이드
+
+## 목적
+
+Virtual Thread 적용 전후를 같은 코드베이스에서 비교한다.
+
+- `Baseline`: JDK 21 + VT 비활성
+- `Candidate`: JDK 21 + VT 활성
+
+이 서비스는 RIOT API rate limit이 강한 병목이라 처리량 증가보다 다음 항목을 본다.
+
+- 플랫폼 스레드 수 감소
+- 대기 중 스레드 점유 감소
+- CPU/메모리 사용량 유지 또는 개선
+- HTTP/RabbitMQ 오류율 유지
+- HikariCP 경합 악화 여부
+- pinned thread 발생 여부
+
+## 토글
+
+현재 비교용 토글은 아래 두 개다.
+
+- `LOL_VT_ENABLED`
+  - Spring `spring.threads.virtual.enabled`에 연결
+  - Servlet 요청 처리 VT on/off
+- `LOL_VT_EXECUTORS_ENABLED`
+  - `requestExecutor`, `matchFindExecutor`, `riotApiExecutor`, Rabbit listener executor VT on/off
+  - 미지정 시 `LOL_VT_ENABLED` 값을 따라감
+
+`timelineSaveExecutor`는 항상 플랫폼 스레드 풀을 유지한다.
+
+## 사전 준비
+
+1. JDK 21 설치
+2. 인프라 실행
+
+```bash
+export PROMETHEUS_SCRAPE_HOST_IP="$(hostname -I | awk '{print $1}')"
+docker compose -f docker/docker-compose.yml up -d
+docker compose -f docker/monitoring/docker-compose.monitoring.yml up -d
+```
+
+WSL 우분투에서는 `host.docker.internal` 대신 `PROMETHEUS_SCRAPE_HOST_IP`에
+현재 WSL 배포판 IP를 넣어 `wsl-app-host:8111`로 수집한다.
+WSL 재시작이나 네트워크 변경 후에는 IP가 바뀔 수 있으므로 값을 다시 갱신해야 한다.
+
+3. Actuator 확인
+
+- Prometheus: `http://localhost:9090`
+- Grafana: `http://localhost:3010`
+- App health: `http://localhost:8080/actuator/health`
+- Thread dump: `http://localhost:8080/actuator/threaddump`
+- Prometheus targets: `http://localhost:9090/targets`
+
+## 실행 방법
+
+### 1. Baseline 실행
+
+```bash
+LOL_VT_ENABLED=false \
+LOL_VT_EXECUTORS_ENABLED=false \
+./run-local.sh
+```
+
+### 2. Candidate 실행
+
+```bash
+LOL_VT_ENABLED=true \
+LOL_VT_EXECUTORS_ENABLED=true \
+JVM_DIAGNOSTIC_OPTS="-Djdk.tracePinnedThreads=short" \
+./run-local.sh
+```
+
+반복 실행 시 재빌드를 건너뛰려면:
+
+```bash
+SKIP_BUILD=true LOL_VT_ENABLED=false LOL_VT_EXECUTORS_ENABLED=false ./run-local.sh
+SKIP_BUILD=true LOL_VT_ENABLED=true LOL_VT_EXECUTORS_ENABLED=true JVM_DIAGNOSTIC_OPTS="-Djdk.tracePinnedThreads=short" ./run-local.sh
+```
+
+## 측정 항목
+
+### 필수 메트릭
+
+- `jvm_threads_live_threads`
+- `jvm_threads_peak_threads`
+- `jvm_memory_used_bytes`
+- `process_cpu_usage`
+- `system_cpu_usage`
+- `hikaricp_connections_active`
+- `hikaricp_connections_pending`
+- `http_server_requests_seconds`
+
+### 추가 확인
+
+- RabbitMQ queue depth
+- RabbitMQ ack/nack 수
+- `/actuator/threaddump`
+- 애플리케이션 로그의 소요시간
+  - `SummonerRenewalService`
+  - `MatchListener`
+  - `TimeLineService`
+- `jdk.tracePinnedThreads` 출력
+
+## 비교 시나리오
+
+### 시나리오 A: HTTP 요청
+
+동일한 소환사/관전 API를 고정 RPS로 5~10분 호출한다.
+
+성공 기준:
+
+- p95/p99 응답시간 유지
+- 에러율 증가 없음
+- live thread 수 감소
+
+### 시나리오 B: RabbitMQ 소비
+
+동일 수량의 메시지를 `SUMMONER`, `RENEWAL_MATCH_FIND`, `MATCH_ID` 큐에 넣고 drain 시간을 비교한다.
+
+성공 기준:
+
+- queue backlog 감소 속도 유지
+- nack/requeue 증가 없음
+- 플랫폼 스레드 수 감소
+
+### 시나리오 C: 혼합 부하
+
+HTTP와 RabbitMQ 부하를 동시에 준다.
+
+성공 기준:
+
+- Hikari pending connection 급증 없음
+- CPU 급등 없음
+- pinned thread가 없거나 제한적
+
+## 권장 수집 절차
+
+1. 워밍업 3분
+2. 본 측정 10분
+3. 실행당 아래 자료 저장
+   - Grafana 스크린샷
+   - Prometheus 메트릭 값
+   - `/actuator/threaddump` 3회
+   - pinned thread 로그
+4. Baseline/Candidate 각각 3회 반복
+5. 평균값과 p95 기준으로 비교
+
+## 해석 기준
+
+다음이면 VT 적용이 유효하다고 본다.
+
+- 처리량이 유지되거나 유사함
+- 에러율 차이가 거의 없음
+- live/peak thread 수가 의미 있게 감소함
+- CPU와 메모리가 유지되거나 소폭 개선됨
+- Hikari pending connection이 늘지 않음
+
+다음이면 재검토가 필요하다.
+
+- pinned thread 로그가 지속적으로 발생
+- Hikari pending connection 급증
+- HTTP p95/p99 악화
+- RabbitMQ nack/requeue 증가
+- queue drain 속도 저하

--- a/infra/persistence/build.gradle
+++ b/infra/persistence/build.gradle
@@ -22,4 +22,14 @@ dependencies {
     // Jackson (캐시 직렬화)
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     runtimeOnly 'org.postgresql:postgresql'
+
+    // Test
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.testcontainers:postgresql'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testRuntimeOnly 'org.postgresql:postgresql'
+}
+
+tasks.named('test') {
+    enabled = true
 }

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/league/scheduler/SummonerRankingCalculationService.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/league/scheduler/SummonerRankingCalculationService.java
@@ -54,9 +54,7 @@ public class SummonerRankingCalculationService {
             summonerRankingRepositoryPort.deleteByQueue(queue);
 
             // 3. 플랫폼 목록 (Platform enum 기반)
-            List<String> platformIds = Arrays.stream(Platform.values())
-                    .map(Platform::getPlatformId)
-                    .toList();
+            List<Platform> platforms = Arrays.asList(Platform.values());
 
             // 티어 커트라인 계산을 위한 데이터 수집 (platformId별)
             Map<String, Integer> minChallengerLPByPlatformId = new HashMap<>();
@@ -67,7 +65,8 @@ public class SummonerRankingCalculationService {
             long totalProcessed = 0;
 
             // 4. 플랫폼별로 순위 계산
-            for (String platformId : platformIds) {
+            for (Platform platform : platforms) {
+                String platformId = platform.getPlatformId();
                 long regionCount = leagueSummonerJpaRepository.countRankingByQueueAndPlatformId(queue, platformId);
                 if (regionCount == 0) {
                     continue;
@@ -147,7 +146,7 @@ public class SummonerRankingCalculationService {
             // 6. 백업 테이블 정리
             summonerRankingRepositoryPort.clearBackup(queue);
 
-            log.info("큐 {} 랭킹 처리 완료: {} 명 ({} 개 플랫폼)", queue, totalProcessed, platformIds.size());
+            log.info("큐 {} 랭킹 처리 완료: {} 명 ({} 개 플랫폼)", queue, totalProcessed, platforms.size());
 
             // 7. 티어 커트라인 저장 (platformId별)
             List<TierCutoff> cutoffs = new ArrayList<>();

--- a/infra/persistence/src/test/java/com/mmrtr/lol/infra/persistence/TestPersistenceConfig.java
+++ b/infra/persistence/src/test/java/com/mmrtr/lol/infra/persistence/TestPersistenceConfig.java
@@ -1,0 +1,7 @@
+package com.mmrtr.lol.infra.persistence;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class TestPersistenceConfig {
+}

--- a/infra/persistence/src/test/java/com/mmrtr/lol/infra/persistence/league/repository/SummonerRankingJpaRepositoryTest.java
+++ b/infra/persistence/src/test/java/com/mmrtr/lol/infra/persistence/league/repository/SummonerRankingJpaRepositoryTest.java
@@ -1,0 +1,189 @@
+package com.mmrtr.lol.infra.persistence.league.repository;
+
+import com.mmrtr.lol.infra.persistence.config.JpaConfig;
+import com.mmrtr.lol.infra.persistence.league.entity.SummonerRankingBackupEntity;
+import com.mmrtr.lol.infra.persistence.league.entity.SummonerRankingEntity;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(JpaConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class SummonerRankingJpaRepositoryTest {
+
+    @Autowired
+    private SummonerRankingJpaRepository summonerRankingJpaRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @BeforeEach
+    void setUp() {
+        entityManager.createNativeQuery("DELETE FROM summoner_ranking_backup").executeUpdate();
+        summonerRankingJpaRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("backupCurrentRanks - 큐별 백업 정상 동작")
+    void backupCurrentRanks_shouldCopyToBackup() {
+        // given
+        SummonerRankingEntity entity1 = createRankingEntity("puuid-1", "RANKED_SOLO_5x5", "KR", 1, "Player1");
+        SummonerRankingEntity entity2 = createRankingEntity("puuid-2", "RANKED_SOLO_5x5", "KR", 2, "Player2");
+        SummonerRankingEntity entity3 = createRankingEntity("puuid-3", "RANKED_FLEX_SR", "KR", 1, "Player3");
+
+        summonerRankingJpaRepository.saveAll(List.of(entity1, entity2, entity3));
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        summonerRankingJpaRepository.backupCurrentRanks("RANKED_SOLO_5x5");
+        entityManager.flush();
+        entityManager.clear();
+
+        // then
+        List<SummonerRankingBackupEntity> backups = entityManager
+                .createQuery("SELECT b FROM SummonerRankingBackupEntity b ORDER BY b.currentRank", SummonerRankingBackupEntity.class)
+                .getResultList();
+
+        assertThat(backups).hasSize(2);
+
+        SummonerRankingBackupEntity backup1 = backups.get(0);
+        assertThat(backup1.getPuuid()).isEqualTo("puuid-1");
+        assertThat(backup1.getQueue()).isEqualTo("RANKED_SOLO_5x5");
+        assertThat(backup1.getPlatformId()).isEqualTo("KR");
+        assertThat(backup1.getCurrentRank()).isEqualTo(1);
+
+        SummonerRankingBackupEntity backup2 = backups.get(1);
+        assertThat(backup2.getPuuid()).isEqualTo("puuid-2");
+        assertThat(backup2.getCurrentRank()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("updateRankChangesFromBackup - 순위 변동 계산")
+    void updateRankChangesFromBackup_shouldCalculateRankChange() {
+        // given: 이전 순위 백업
+        SummonerRankingEntity entity = createRankingEntity("puuid-1", "RANKED_SOLO_5x5", "KR", 5, "Player1");
+
+        summonerRankingJpaRepository.save(entity);
+        entityManager.flush();
+
+        // 현재 순위를 백업 (이전 순위 = 5)
+        summonerRankingJpaRepository.backupCurrentRanks("RANKED_SOLO_5x5");
+        entityManager.flush();
+
+        // 새 순위로 데이터 삭제 후 재삽입 (새 순위 = 3, 2단계 상승)
+        summonerRankingJpaRepository.deleteByQueue("RANKED_SOLO_5x5");
+        entityManager.flush();
+        entityManager.clear();
+
+        SummonerRankingEntity newEntity = createRankingEntity("puuid-1", "RANKED_SOLO_5x5", "KR", 3, "Player1");
+        summonerRankingJpaRepository.save(newEntity);
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        summonerRankingJpaRepository.updateRankChangesFromBackup("RANKED_SOLO_5x5");
+        entityManager.flush();
+        entityManager.clear();
+
+        // then: rankChange = backup.current_rank(5) - new.current_rank(3) = 2
+        SummonerRankingEntity result = summonerRankingJpaRepository.findAll().get(0);
+        assertThat(result.getRankChange()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("clearBackup - 백업 데이터 정리")
+    void clearBackup_shouldDeleteBackupByQueue() {
+        // given
+        SummonerRankingEntity entity = createRankingEntity("puuid-1", "RANKED_SOLO_5x5", "KR", 1, "Player1");
+
+        summonerRankingJpaRepository.save(entity);
+        entityManager.flush();
+
+        summonerRankingJpaRepository.backupCurrentRanks("RANKED_SOLO_5x5");
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        summonerRankingJpaRepository.clearBackup("RANKED_SOLO_5x5");
+        entityManager.flush();
+        entityManager.clear();
+
+        // then
+        Long count = (Long) entityManager
+                .createQuery("SELECT COUNT(b) FROM SummonerRankingBackupEntity b")
+                .getSingleResult();
+        assertThat(count).isZero();
+    }
+
+    @Test
+    @DisplayName("backupCurrentRanks - 다중 플랫폼 백업")
+    void backupCurrentRanks_multiPlatform_shouldCopyAllPlatforms() {
+        // given
+        SummonerRankingEntity krEntity = createRankingEntity("puuid-kr", "RANKED_SOLO_5x5", "KR", 1, "KRPlayer");
+        SummonerRankingEntity naEntity = SummonerRankingEntity.builder()
+                .puuid("puuid-na")
+                .queue("RANKED_SOLO_5x5")
+                .platformId("NA1")
+                .currentRank(1)
+                .rankChange(0)
+                .gameName("NAPlayer")
+                .tagLine("NA1")
+                .wins(80)
+                .losses(60)
+                .winRate(BigDecimal.valueOf(57.14))
+                .tier("GRANDMASTER")
+                .rank("I")
+                .leaguePoints(700)
+                .build();
+
+        summonerRankingJpaRepository.saveAll(List.of(krEntity, naEntity));
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        summonerRankingJpaRepository.backupCurrentRanks("RANKED_SOLO_5x5");
+        entityManager.flush();
+        entityManager.clear();
+
+        // then
+        List<SummonerRankingBackupEntity> backups = entityManager
+                .createQuery("SELECT b FROM SummonerRankingBackupEntity b ORDER BY b.platformId", SummonerRankingBackupEntity.class)
+                .getResultList();
+
+        assertThat(backups).hasSize(2);
+        assertThat(backups).extracting(SummonerRankingBackupEntity::getPlatformId)
+                .containsExactly("KR", "NA1");
+    }
+
+    private SummonerRankingEntity createRankingEntity(String puuid, String queue, String platformId, int rank, String gameName) {
+        return SummonerRankingEntity.builder()
+                .puuid(puuid)
+                .queue(queue)
+                .platformId(platformId)
+                .currentRank(rank)
+                .rankChange(0)
+                .gameName(gameName)
+                .tagLine("KR1")
+                .wins(100)
+                .losses(50)
+                .winRate(BigDecimal.valueOf(66.67))
+                .tier("CHALLENGER")
+                .rank("I")
+                .leaguePoints(1000)
+                .build();
+    }
+}

--- a/infra/persistence/src/test/resources/application-test.yml
+++ b/infra/persistence/src/test/resources/application-test.yml
@@ -1,0 +1,15 @@
+spring:
+  datasource:
+    url: jdbc:tc:postgresql:16-alpine:///test
+    username: test
+    password: test
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+  jpa:
+    hibernate:
+      ddl-auto: none
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+  flyway:
+    enabled: true
+    locations: classpath:db/migration

--- a/infra/rabbitmq/src/main/java/com/mmrtr/lol/infra/rabbitmq/config/RabbitMqConfig.java
+++ b/infra/rabbitmq/src/main/java/com/mmrtr/lol/infra/rabbitmq/config/RabbitMqConfig.java
@@ -8,10 +8,18 @@ import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.amqp.SimpleRabbitListenerContainerFactoryConfigurer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.core.task.support.TaskExecutorAdapter;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 @Configuration
 @EnableRabbit
@@ -126,15 +134,34 @@ public class RabbitMqConfig {
         return new Jackson2JsonMessageConverter();
     }
 
+    @Bean(name = "rabbitListenerExecutor", destroyMethod = "close")
+    @ConditionalOnProperty(name = "lol.vt.executors.enabled", havingValue = "true", matchIfMissing = true)
+    public ExecutorService rabbitListenerExecutor() {
+        return Executors.newThreadPerTaskExecutor(
+                Thread.ofVirtual()
+                        .name("rabbit-listener-vt-", 0)
+                        .factory()
+        );
+    }
+
+    @Bean(name = "rabbitListenerTaskExecutor")
+    @ConditionalOnProperty(name = "lol.vt.executors.enabled", havingValue = "true", matchIfMissing = true)
+    public TaskExecutor rabbitListenerTaskExecutor(ExecutorService rabbitListenerExecutor) {
+        return new TaskExecutorAdapter(rabbitListenerExecutor);
+    }
+
     @Bean
     public SimpleRabbitListenerContainerFactory simpleRabbitListenerContainerFactory(
             SimpleRabbitListenerContainerFactoryConfigurer configurer,
-            ConnectionFactory factory
+            ConnectionFactory factory,
+            @Qualifier("rabbitListenerTaskExecutor")
+            ObjectProvider<TaskExecutor> rabbitListenerTaskExecutorProvider
     ) {
         SimpleRabbitListenerContainerFactory simpleFactory = new SimpleRabbitListenerContainerFactory();
         configurer.configure(simpleFactory, factory);
 
         simpleFactory.setChannelTransacted(true);
+        rabbitListenerTaskExecutorProvider.ifAvailable(simpleFactory::setTaskExecutor);
 
         simpleFactory.setConcurrentConsumers(1);
         simpleFactory.setMaxConcurrentConsumers(1);
@@ -148,11 +175,14 @@ public class RabbitMqConfig {
     @Bean
     public SimpleRabbitListenerContainerFactory findQueueSimpleRabbitListenerContainerFactory(
             SimpleRabbitListenerContainerFactoryConfigurer configurer,
-            ConnectionFactory factory
+            ConnectionFactory factory,
+            @Qualifier("rabbitListenerTaskExecutor")
+            ObjectProvider<TaskExecutor> rabbitListenerTaskExecutorProvider
     ) {
         SimpleRabbitListenerContainerFactory simpleFactory = new SimpleRabbitListenerContainerFactory();
         configurer.configure(simpleFactory, factory);
 
+        rabbitListenerTaskExecutorProvider.ifAvailable(simpleFactory::setTaskExecutor);
         simpleFactory.setConcurrentConsumers(5);
         simpleFactory.setMaxConcurrentConsumers(5);
 
@@ -165,12 +195,15 @@ public class RabbitMqConfig {
     @Bean
     public SimpleRabbitListenerContainerFactory batchRabbitListenerContainerFactory(
             SimpleRabbitListenerContainerFactoryConfigurer configurer,
-            ConnectionFactory factory
+            ConnectionFactory factory,
+            @Qualifier("rabbitListenerTaskExecutor")
+            ObjectProvider<TaskExecutor> rabbitListenerTaskExecutorProvider
     ) {
 
         SimpleRabbitListenerContainerFactory simpleFactory = new SimpleRabbitListenerContainerFactory();
         configurer.configure(simpleFactory, factory);
 
+        rabbitListenerTaskExecutorProvider.ifAvailable(simpleFactory::setTaskExecutor);
         simpleFactory.setConcurrentConsumers(20);
         simpleFactory.setMaxConcurrentConsumers(20);
 

--- a/infra/riot-client/src/main/java/com/mmrtr/lol/infra/riot/config/AsyncConfig.java
+++ b/infra/riot-client/src/main/java/com/mmrtr/lol/infra/riot/config/AsyncConfig.java
@@ -1,63 +1,81 @@
 package com.mmrtr.lol.infra.riot.config;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
 
 @Configuration
 public class AsyncConfig {
 
-    @Bean
-    public Executor requestExecutor() {
-        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(20);
-        executor.setMaxPoolSize(40);
-        executor.setQueueCapacity(100);
-        executor.setKeepAliveSeconds(60);
-
-        executor.setThreadNamePrefix("Request Thread-");
-        executor.initialize();
-
-        return executor;
+    @Bean(name = "requestExecutor", destroyMethod = "close")
+    @ConditionalOnProperty(name = "lol.vt.executors.enabled", havingValue = "true", matchIfMissing = true)
+    public ExecutorService virtualRequestExecutor() {
+        return newVirtualThreadExecutor("request-vt-", 0);
     }
 
-    @Bean
-    public Executor matchFindExecutor() {
-        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(5);
-        executor.setMaxPoolSize(10);
-        executor.setQueueCapacity(20);
-        executor.setKeepAliveSeconds(60);
-        executor.setThreadNamePrefix("MatchFind Thread-");
-        executor.initialize();
-        return executor;
+    @Bean(name = "requestExecutor")
+    @ConditionalOnProperty(name = "lol.vt.executors.enabled", havingValue = "false")
+    public Executor platformRequestExecutor() {
+        return newPlatformThreadPoolExecutor(20, 40, 100, "Request Thread-");
     }
 
-    @Bean
-    public Executor riotApiExecutor() {
-        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(20);
-        executor.setMaxPoolSize(40);
-        executor.setQueueCapacity(40);
+    @Bean(name = "matchFindExecutor", destroyMethod = "close")
+    @ConditionalOnProperty(name = "lol.vt.executors.enabled", havingValue = "true", matchIfMissing = true)
+    public ExecutorService virtualMatchFindExecutor() {
+        return newVirtualThreadExecutor("match-find-vt-", 0);
+    }
 
-        executor.setKeepAliveSeconds(60);
-        executor.setThreadNamePrefix("Riot API Thread-");
-        executor.initialize();
-        return executor;
+    @Bean(name = "matchFindExecutor")
+    @ConditionalOnProperty(name = "lol.vt.executors.enabled", havingValue = "false")
+    public Executor platformMatchFindExecutor() {
+        return newPlatformThreadPoolExecutor(5, 10, 20, "MatchFind Thread-");
+    }
+
+    @Bean(name = "riotApiExecutor", destroyMethod = "close")
+    @ConditionalOnProperty(name = "lol.vt.executors.enabled", havingValue = "true", matchIfMissing = true)
+    public ExecutorService virtualRiotApiExecutor() {
+        return newVirtualThreadExecutor("riot-api-vt-", 0);
+    }
+
+    @Bean(name = "riotApiExecutor")
+    @ConditionalOnProperty(name = "lol.vt.executors.enabled", havingValue = "false")
+    public Executor platformRiotApiExecutor() {
+        return newPlatformThreadPoolExecutor(20, 40, 40, "Riot API Thread-");
     }
 
     @Bean
     public Executor timelineSaveExecutor() {
-        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(10);
-        executor.setMaxPoolSize(10);
-        executor.setQueueCapacity(0);
-        executor.setKeepAliveSeconds(60);
-        executor.setThreadNamePrefix("TimelineSave-");
+        ThreadPoolTaskExecutor executor = newPlatformThreadPoolExecutor(10, 10, 0, "TimelineSave-");
         executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        return executor;
+    }
+
+    private ExecutorService newVirtualThreadExecutor(String prefix, long startIndex) {
+        return Executors.newThreadPerTaskExecutor(
+                Thread.ofVirtual()
+                        .name(prefix, startIndex)
+                        .factory()
+        );
+    }
+
+    private ThreadPoolTaskExecutor newPlatformThreadPoolExecutor(
+            int corePoolSize,
+            int maxPoolSize,
+            int queueCapacity,
+            String threadNamePrefix
+    ) {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(corePoolSize);
+        executor.setMaxPoolSize(maxPoolSize);
+        executor.setQueueCapacity(queueCapacity);
+        executor.setKeepAliveSeconds(60);
+        executor.setThreadNamePrefix(threadNamePrefix);
         executor.initialize();
         return executor;
     }

--- a/run-local.sh
+++ b/run-local.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# .env 파일 로드 (있으면)
+ENV_FILE="$SCRIPT_DIR/.env"
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  source "$ENV_FILE"
+  set +a
+fi
+
+# Git 서브모듈 업데이트 (이 프로젝트는 lol-db-schema 서브모듈 사용)
+git submodule update --init --recursive
+
+echo "==> Gradle 빌드..."
+if [ "${SKIP_BUILD:-false}" != "true" ]; then
+  "$SCRIPT_DIR/gradlew" build -x test --no-daemon
+fi
+
+JAR_FILE="$SCRIPT_DIR/app/build/libs/app-0.0.1-SNAPSHOT.jar"
+LOL_VT_ENABLED="${LOL_VT_ENABLED:-true}"
+LOL_VT_EXECUTORS_ENABLED="${LOL_VT_EXECUTORS_ENABLED:-$LOL_VT_ENABLED}"
+JVM_DIAGNOSTIC_OPTS="${JVM_DIAGNOSTIC_OPTS:-}"
+MANAGEMENT_ENDPOINTS_EXPOSURE_INCLUDE="${MANAGEMENT_ENDPOINTS_EXPOSURE_INCLUDE:-health,info,metrics,prometheus,threaddump}"
+
+echo "==> 애플리케이션 실행 (local 프로파일, VT=${LOL_VT_ENABLED}, executors=${LOL_VT_EXECUTORS_ENABLED})..."
+LOL_VT_ENABLED="$LOL_VT_ENABLED" \
+LOL_VT_EXECUTORS_ENABLED="$LOL_VT_EXECUTORS_ENABLED" \
+MANAGEMENT_ENDPOINTS_EXPOSURE_INCLUDE="$MANAGEMENT_ENDPOINTS_EXPOSURE_INCLUDE" \
+java \
+  ${JVM_DIAGNOSTIC_OPTS} \
+  -DDB_HOST="${DB_HOST:-localhost}" \
+  -DDB_PORT="${DB_PORT:-5432}" \
+  -DDB_NAME="${DB_NAME:-postgres}" \
+  -DDB_USERNAME="${DB_USERNAME:-postgres}" \
+  -DDB_PASSWORD="${DB_PASSWORD:-1234}" \
+  -jar "$JAR_FILE" \
+  --spring.profiles.active=local


### PR DESCRIPTION
## Summary
- upgrade the project to JDK 21 and Spring Boot 3.5.9
- add virtual thread toggles for Spring, async executors, and RabbitMQ listeners
- document local VT monitoring and comparison workflow

## Verification
- GRADLE_USER_HOME=/tmp/gradle-home ./gradlew build --no-daemon
- verified the full multi-module build succeeds under Spring Boot 3.5.9
