### PR TITLE
refactor: 트랜잭션 경계 최적화 - 외부 API 호출 분리 및 readOnly 명시

### DIFF
--- a/core/domain/src/main/java/com/mmrtr/lol/domain/summoner/application/SummonerService.java
+++ b/core/domain/src/main/java/com/mmrtr/lol/domain/summoner/application/SummonerService.java
@@ -8,7 +8,6 @@ import com.mmrtr.lol.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.concurrent.Executor;
 
@@ -21,7 +20,6 @@ public class SummonerService {
     private final SaveSummonerDataUseCase saveSummonerDataUseCase;
     private final Executor requestExecutor;
 
-    @Transactional
     public Summoner getSummonerInfoV2(String regionType, String gameName, String tagLine) {
         try {
             Summoner summoner = summonerApiPort
@@ -42,7 +40,6 @@ public class SummonerService {
         }
     }
 
-    @Transactional
     public Summoner getSummonerByPuuid(String regionType, String puuid) {
         try {
             Summoner summoner = summonerApiPort

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/league/repository/LeagueSummonerRepositoryImpl.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/league/repository/LeagueSummonerRepositoryImpl.java
@@ -7,6 +7,8 @@ import com.mmrtr.lol.infra.persistence.league.entity.LeagueSummonerHistoryEntity
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import org.springframework.transaction.annotation.Transactional;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -39,18 +41,21 @@ public class LeagueSummonerRepositoryImpl implements LeagueSummonerRepositoryPor
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Optional<LeagueSummoner> findBy(String puuid, String leagueId) {
         return jpaRepository.findByPuuidAndLeagueId(puuid, leagueId)
                 .map(LeagueSummonerEntity::toDomain);
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Optional<LeagueSummoner> findByPuuidAndQueue(String puuid, String queue) {
         return jpaRepository.findAllByPuuidAndQueue(puuid, queue)
                 .map(LeagueSummonerEntity::toDomain);
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<LeagueSummoner> findAllByPuuidsAndQueue(Set<String> puuids, String queue) {
         return jpaRepository.findAllByPuuidInAndQueue(puuids, queue).stream()
                 .map(LeagueSummonerEntity::toDomain)

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/repository/TimeLineRepositoryImpl.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/repository/TimeLineRepositoryImpl.java
@@ -7,6 +7,7 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -331,6 +332,7 @@ public class TimeLineRepositoryImpl {
         jdbcTemplate.batchUpdate(sql, params);
     }
 
+    @Transactional(readOnly = true)
     public Set<String> findExistingMatchIds(List<String> matchIds) {
         if (matchIds.isEmpty()) return Collections.emptySet();
 

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/service/MatchService.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/service/MatchService.java
@@ -143,6 +143,7 @@ public class MatchService implements MatchRepositoryPort {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<String> findExistingMatchIds(List<String> matchIds) {
         return matchRepository.findAllByIds(matchIds).stream()
                 .map(MatchEntity::getMatchId)

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/summoner/repository/SummonerRepositoryImpl.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/summoner/repository/SummonerRepositoryImpl.java
@@ -22,6 +22,7 @@ public class SummonerRepositoryImpl implements SummonerRepositoryPort {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Optional<Summoner> findByPuuid(String puuid) {
         return jpaRepository.findById(puuid)
                 .map(SummonerEntity::toDomain);


### PR DESCRIPTION
## Summary
- `SummonerService`에서 RIOT API 호출을 포함하는 메서드의 `@Transactional` 제거하여 불필요한 DB 커넥션 풀 점유 방지 (쓰기는 `SaveSummonerDataUseCase`에서 처리)
- 읽기 전용 Repository 메서드에 `@Transactional(readOnly = true)` 추가 (`LeagueSummonerRepositoryImpl`, `TimeLineRepositoryImpl`, `MatchService`, `SummonerRepositoryImpl`)
- Hibernate dirty checking 오버헤드 감소 및 read replica 라우팅 가능

## Test plan
- [ ] `SummonerRenewalService.renewSummoner()` 플로우 정상 동작 확인
- [ ] 소환사 조회 API (`getSummonerInfoV2`, `getSummonerByPuuid`) 정상 동작 확인
- [ ] 매치 ID 조회 (`findExistingMatchIds`) 정상 동작 확인
- [ ] 리그 정보 조회 메서드 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)