### PR TITLE
ci: 테스트 활성화, JaCoCo 커버리지, Checkstyle, Dependabot 추가

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+updates:
+  # Gradle 의존성
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    groups:
+      spring-boot:
+        patterns:
+          - "org.springframework.boot*"
+          - "org.springframework:*"
+          - "io.spring.dependency-management"
+      testing:
+        patterns:
+          - "org.testcontainers:*"
+          - "org.junit*"
+      redis:
+        patterns:
+          - "org.redisson:*"
+          - "org.springframework.boot:spring-boot-starter-data-redis"
+
+  # GitHub Actions 의존성
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@ updates:
   # Gradle 의존성
   - package-ecosystem: "gradle"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -29,6 +30,7 @@ updates:
   # GitHub Actions 의존성
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,10 @@ on:
 
 jobs:
   build:
-    name: Build
+    name: Build & Test
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -22,8 +24,27 @@ jobs:
           java-version: 21
           cache: gradle
 
-      - name: Build
-        run: ./gradlew :app:bootJar -x test --no-daemon
+      - name: Build & Test
+        run: ./gradlew :app:bootJar --no-daemon
+
+      - name: Checkstyle
+        if: always()
+        run: ./gradlew checkstyleMain --no-daemon
+
+      - name: Generate JaCoCo Report
+        if: always()
+        run: ./gradlew jacocoTestReport --no-daemon
+
+      - name: Add Coverage to PR
+        if: github.event_name == 'pull_request'
+        uses: madrapps/jacoco-report@v1.7.1
+        with:
+          paths: '**/build/reports/jacoco/test/jacocoTestReport.xml'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 0
+          min-coverage-changed-files: 0
+          title: 'Code Coverage Report'
+          update-comment: true
 
   notify:
     name: Slack Notification

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,8 @@ subprojects {
     apply plugin: 'java-library'
     apply plugin: 'org.springframework.boot'
     apply plugin: 'io.spring.dependency-management'
+    apply plugin: 'jacoco'
+    apply plugin: 'checkstyle'
 
     java {
         toolchain {
@@ -46,12 +48,33 @@ subprojects {
         testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     }
 
-    tasks.named('test') {
-        useJUnitPlatform()
+    checkstyle {
+        toolVersion = '10.21.4'
+        configFile = rootProject.file('config/checkstyle/checkstyle.xml')
+        configProperties = ['suppressionFile': rootProject.file('config/checkstyle/suppressions.xml')]
+        maxWarnings = 0
     }
 
-    tasks.withType(Test).configureEach {
+    tasks.named('checkstyleTest') {
         enabled = false
+    }
+
+    jacoco {
+        toolVersion = "0.8.12"
+    }
+
+    tasks.named('test') {
+        useJUnitPlatform()
+        finalizedBy jacocoTestReport
+    }
+
+    jacocoTestReport {
+        dependsOn test
+        reports {
+            xml.required = true
+            html.required = true
+            csv.required = false
+        }
     }
 
     tasks.withType(JavaCompile).configureEach {

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+    <property name="charset" value="UTF-8"/>
+    <property name="severity" value="warning"/>
+    <property name="fileExtensions" value="java"/>
+
+    <!-- 파일 레벨 체크 -->
+    <module name="FileTabCharacter">
+        <property name="eachLine" value="true"/>
+    </module>
+    <module name="NewlineAtEndOfFile"/>
+    <module name="FileLength">
+        <property name="max" value="500"/>
+    </module>
+
+    <!-- 라인 길이 (Checker 레벨) -->
+    <module name="LineLength">
+        <property name="max" value="200"/>
+        <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+    </module>
+
+    <!-- Suppression 필터 -->
+    <module name="SuppressionFilter">
+        <property name="file" value="${suppressionFile}"/>
+        <property name="optional" value="true"/>
+    </module>
+
+    <module name="TreeWalker">
+        <!-- Import 규칙 -->
+        <module name="UnusedImports"/>
+        <module name="RedundantImport"/>
+
+        <!-- 네이밍 규칙 -->
+        <module name="TypeName"/>
+        <module name="MethodName"/>
+        <module name="ConstantName"/>
+        <module name="PackageName"/>
+
+        <!-- 코드 품질 -->
+        <module name="EmptyBlock"/>
+        <module name="OneStatementPerLine"/>
+        <module name="SimplifyBooleanExpression"/>
+        <module name="SimplifyBooleanReturn"/>
+
+        <!-- 공백 -->
+        <module name="WhitespaceAround">
+            <property name="allowEmptyConstructors" value="true"/>
+            <property name="allowEmptyMethods" value="true"/>
+            <property name="allowEmptyTypes" value="true"/>
+            <property name="allowEmptyLambdas" value="true"/>
+        </module>
+        <module name="GenericWhitespace"/>
+
+        <!-- 수정자 순서 -->
+        <module name="ModifierOrder"/>
+        <module name="RedundantModifier"/>
+
+        <!-- Annotation -->
+        <module name="MissingOverride"/>
+    </module>
+</module>

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!DOCTYPE suppressions PUBLIC
+        "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+        "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+    <!-- Repository 구현체의 긴 파일 허용 -->
+    <suppress checks="FileLength" files=".*RepositoryImpl\.java"/>
+    <!-- Entity 클래스의 긴 파일 허용 -->
+    <suppress checks="FileLength" files=".*Entity\.java"/>
+    <!-- Service 클래스의 긴 파일 허용 -->
+    <suppress checks="FileLength" files=".*Service\.java"/>
+</suppressions>

--- a/infra/persistence/build.gradle
+++ b/infra/persistence/build.gradle
@@ -28,7 +28,3 @@ dependencies {
     testImplementation 'org.testcontainers:junit-jupiter'
     testRuntimeOnly 'org.postgresql:postgresql'
 }
-
-tasks.named('test') {
-    enabled = true
-}

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/entity/MatchEntity.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/entity/MatchEntity.java
@@ -39,33 +39,33 @@ public class MatchEntity {
     @Comment("게임 종료 결과")
     private String endOfGameResult;
     @Comment("게임 생성 타임스탬프")
-    private	long gameCreation;
+    private    long gameCreation;
     @Comment("게임 진행 시간 (초)")
-    private	long gameDuration;
+    private    long gameDuration;
     @Comment("게임 종료 타임스탬프")
-    private	long gameEndTimestamp;
+    private    long gameEndTimestamp;
     @Comment("게임 시작 타임스탬프")
-    private	long gameStartTimestamp;
+    private    long gameStartTimestamp;
     @Comment("게임 ID")
-    private	long gameId;
+    private    long gameId;
     @Comment("게임 모드")
-    private	String gameMode;
+    private    String gameMode;
     @Comment("게임 이름")
-    private	String gameName;
+    private    String gameName;
     @Comment("게임 타입")
-    private	String gameType;
+    private    String gameType;
 
     @Comment("게임 버전")
-    private	String gameVersion;
+    private    String gameVersion;
 
     @Comment("맵 ID")
-    private	int mapId;
+    private    int mapId;
     @Comment("큐 ID")
-    private	int queueId;
+    private    int queueId;
     @Comment("플랫폼 ID")
-    private	String platformId;
+    private    String platformId;
     @Comment("토너먼트 코드")
-    private	String tournamentCode;
+    private    String tournamentCode;
 
     // 시즌
     @Comment("시즌")

--- a/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/repository/MatchRepositoryImpl.java
+++ b/infra/persistence/src/main/java/com/mmrtr/lol/infra/persistence/match/repository/MatchRepositoryImpl.java
@@ -32,7 +32,7 @@ public class MatchRepositoryImpl {
         return matchJpaRepository.findAllByMatchIdIn(matchIds);
     }
 
-    public MatchEntity save(MatchEntity match){
+    public MatchEntity save(MatchEntity match) {
         return matchJpaRepository.save(match);
     }
 


### PR DESCRIPTION
## Summary
- 전역 테스트 비활성화 제거 및 JaCoCo 커버리지 리포트 설정
- Checkstyle 정적 분석 플러그인 및 규칙 파일 추가
- CI 워크플로우에 테스트, Checkstyle, JaCoCo 리포트 단계 추가
- PR 커버리지 코멘트 자동 게시 (`madrapps/jacoco-report`)
- Dependabot 설정 추가 (Gradle + GitHub Actions 주간 자동 업데이트)
- 기존 코드 Checkstyle 위반 수정 (탭 문자, 공백)

## 변경 파일
| 파일 | 변경 내용 |
|------|-----------|
| `build.gradle` | 테스트 비활성화 제거, JaCoCo + Checkstyle 플러그인 추가 |
| `infra/persistence/build.gradle` | 불필요한 `enabled = true` 제거 |
| `.github/workflows/ci.yml` | 테스트, Checkstyle, JaCoCo 리포트 단계 추가 |
| `config/checkstyle/checkstyle.xml` | Checkstyle 규칙 정의 |
| `config/checkstyle/suppressions.xml` | RepositoryImpl/Entity/Service 파일 길이 예외 |
| `.github/dependabot.yml` | Gradle + GitHub Actions 주간 자동 업데이트 |
| `MatchEntity.java` | 탭→공백 변환 (Checkstyle 위반 수정) |
| `MatchRepositoryImpl.java` | `{` 앞 공백 추가 (Checkstyle 위반 수정) |

## Test plan
- [x] `./gradlew checkstyleMain` 전 모듈 통과 확인
- [x] `./gradlew test` 테스트 실행 확인 (persistence 모듈 테스트 통과, 나머지 NO-SOURCE 스킵)
- [x] `./gradlew :app:bootJar` 빌드 성공 확인
- [ ] CI 워크플로우에서 Build & Test → Checkstyle → JaCoCo 리포트 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)