### PR TITLE
feat: deploy 워크플로우에 CD 저장소 dispatch 트리거 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,3 +56,18 @@ jobs:
             ${{ steps.ecr-login.outputs.registry }}/${{ vars.ECR_REPOSITORY }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Trigger CD deployment
+        uses: peter-evans/repository-dispatch@v4
+        with:
+          token: ${{ secrets.CD_REPO_TOKEN }}
+          repository: ${{ vars.CD_REPO }}
+          event-type: deploy
+          client-payload: >-
+            {
+              "image": "${{ steps.ecr-login.outputs.registry }}/${{ vars.ECR_REPOSITORY }}",
+              "version": "${{ steps.version.outputs.version }}",
+              "sha": "${{ github.event.workflow_run.head_sha }}",
+              "sha_short": "${{ steps.version.outputs.sha_short }}",
+              "tag": "${{ steps.version.outputs.version }}-${{ steps.version.outputs.sha_short }}"
+            }


### PR DESCRIPTION
## Summary
- ECR 빌드·푸시 이후 `peter-evans/repository-dispatch@v4`로 CD 저장소에 `deploy` 이벤트를 전송하는 스텝 추가
- 클라이언트 페이로드: `image`, `version`, `sha`, `sha_short`, `tag`
- 이미지 빌드(현재 레포)와 실제 배포(CD 레포) 책임 분리

## 전제
- GitHub 시크릿/변수 `secrets.CD_REPO_TOKEN`, `vars.CD_REPO` 가 사전 구성되어 있어야 함

## Test plan
- [ ] `secrets.CD_REPO_TOKEN`, `vars.CD_REPO` 설정 확인
- [ ] main 머지 후 CI → Deploy 워크플로우가 성공으로 끝나는지 확인
- [ ] CD 저장소에서 `repository_dispatch` (type=deploy) 이벤트 수신 및 페이로드 검증
- [ ] ECR에 `<version>-<sha_short>` / `latest` 태그가 모두 푸시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)