### PR TITLE
feat: MP-6 백필 다중 fact-type 전환 + 챔피언 픽 통계 BQ MV/쿼리

### DIFF
--- a/app/src/main/java/com/mmrtr/lol/backfill/BackfillController.java
+++ b/app/src/main/java/com/mmrtr/lol/backfill/BackfillController.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 @RestController
-@RequestMapping("/internal/backfill/match-participant-build")
+@RequestMapping("/internal/backfill/{factType}")
 public class BackfillController {
 
     private final JobLauncher jobLauncher;
@@ -30,21 +30,26 @@ public class BackfillController {
 
     public BackfillController(
             @Qualifier("backfillJobLauncher") JobLauncher jobLauncher,
-            Job matchParticipantBuildBackfillJob,
+            Job lolBackfillJob,
             BackfillProgressService progressService
     ) {
         this.jobLauncher = jobLauncher;
-        this.job = matchParticipantBuildBackfillJob;
+        this.job = lolBackfillJob;
         this.progressService = progressService;
     }
 
     @PostMapping("/run")
-    public ResponseEntity<Map<String, Object>> run(@RequestBody(required = false) RunRequest request) {
+    public ResponseEntity<Map<String, Object>> run(
+            @PathVariable String factType,
+            @RequestBody(required = false) RunRequest request
+    ) {
+        BackfillFactType type = BackfillFactType.fromCode(factType);
         String runId = (request != null && request.runId() != null)
                 ? request.runId()
                 : "run-" + Instant.now().toEpochMilli();
 
         JobParametersBuilder builder = new JobParametersBuilder()
+                .addString("factType", type.code(), true)
                 .addString("runId", runId, true);
         if (request != null) {
             if (request.startId() != null) {
@@ -55,25 +60,34 @@ public class BackfillController {
             }
         }
 
-        return launch(runId, builder.toJobParameters());
+        return launch(type, runId, builder.toJobParameters());
     }
 
     /**
-     * 이전 실행의 jobParameters(runId/startId/endId) 를 그대로 재사용해서 재실행.
+     * 이전 실행의 jobParameters(factType/runId/startId/endId) 를 그대로 재사용해서 재실행.
      * Spring Batch 가 같은 JobInstance 로 인식하여 COMPLETED 청크는 자동 스킵.
      */
     @PostMapping("/runs/{runId}/resume")
-    public ResponseEntity<Map<String, Object>> resume(@PathVariable String runId) {
-        return progressService.findLatestExecutionByRunId(runId)
-                .map(prev -> launch(runId, prev.getJobParameters()))
+    public ResponseEntity<Map<String, Object>> resume(
+            @PathVariable String factType,
+            @PathVariable String runId
+    ) {
+        BackfillFactType type = BackfillFactType.fromCode(factType);
+        return progressService.findLatestExecutionByRunId(type, runId)
+                .map(prev -> launch(type, runId, prev.getJobParameters()))
                 .orElse(ResponseEntity.notFound().build());
     }
 
-    private ResponseEntity<Map<String, Object>> launch(String runId, JobParameters params) {
+    private ResponseEntity<Map<String, Object>> launch(
+            BackfillFactType type,
+            String runId,
+            JobParameters params
+    ) {
         try {
             JobExecution execution = jobLauncher.run(job, params);
             return ResponseEntity.ok(Map.of(
                     "jobName", BackfillJobConfig.JOB_NAME,
+                    "factType", type.code(),
                     "runId", runId,
                     "jobExecutionId", execution.getId(),
                     "status", execution.getStatus().toString()
@@ -85,21 +99,28 @@ public class BackfillController {
 
     @GetMapping("/runs")
     public List<BackfillProgressService.RunSummary> listRuns(
+            @PathVariable String factType,
             @RequestParam(name = "limit", defaultValue = "20") int limit
     ) {
-        return progressService.listRecentRuns(limit);
+        return progressService.listRecentRuns(BackfillFactType.fromCode(factType), limit);
     }
 
     @GetMapping("/runs/{runId}")
-    public ResponseEntity<BackfillProgressService.RunProgress> getRun(@PathVariable String runId) {
-        return progressService.getProgressByRunId(runId)
+    public ResponseEntity<BackfillProgressService.RunProgress> getRun(
+            @PathVariable String factType,
+            @PathVariable String runId
+    ) {
+        return progressService.getProgressByRunId(BackfillFactType.fromCode(factType), runId)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
     }
 
     @GetMapping("/runs/{runId}/failed-chunks")
-    public ResponseEntity<List<BackfillProgressService.ChunkProgress>> getFailedChunks(@PathVariable String runId) {
-        return progressService.getProgressByRunId(runId)
+    public ResponseEntity<List<BackfillProgressService.ChunkProgress>> getFailedChunks(
+            @PathVariable String factType,
+            @PathVariable String runId
+    ) {
+        return progressService.getProgressByRunId(BackfillFactType.fromCode(factType), runId)
                 .map(progress -> progress.chunks().stream()
                         .filter(BackfillProgressService.ChunkProgress::isFailed)
                         .toList())
@@ -108,7 +129,11 @@ public class BackfillController {
     }
 
     @GetMapping("/executions/{jobExecutionId}")
-    public ResponseEntity<BackfillProgressService.RunProgress> getExecution(@PathVariable long jobExecutionId) {
+    public ResponseEntity<BackfillProgressService.RunProgress> getExecution(
+            @PathVariable String factType,
+            @PathVariable long jobExecutionId
+    ) {
+        BackfillFactType.fromCode(factType);
         return progressService.getProgressByExecutionId(jobExecutionId)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());

--- a/app/src/main/java/com/mmrtr/lol/backfill/BackfillFactType.java
+++ b/app/src/main/java/com/mmrtr/lol/backfill/BackfillFactType.java
@@ -1,0 +1,47 @@
+package com.mmrtr.lol.backfill;
+
+public enum BackfillFactType {
+
+    MATCH("match",
+            "sql/match-aggregation.sql",
+            "match/backfill"),
+    MATCH_BAN("match-ban",
+            "sql/match-ban-aggregation.sql",
+            "match_ban/backfill"),
+    MATCH_PARTICIPANT_BUILD("match-participant-build",
+            "sql/match-participant-build-aggregation.sql",
+            "match_participant_build/backfill");
+
+    private final String code;
+    private final String sqlResourcePath;
+    private final String gcsPrefix;
+
+    BackfillFactType(String code, String sqlResourcePath, String gcsPrefix) {
+        this.code = code;
+        this.sqlResourcePath = sqlResourcePath;
+        this.gcsPrefix = gcsPrefix;
+    }
+
+    public String code() {
+        return code;
+    }
+
+    public String sqlResourcePath() {
+        return sqlResourcePath;
+    }
+
+    public String gcsPrefix() {
+        return gcsPrefix;
+    }
+
+    public static BackfillFactType fromCode(String code) {
+        for (BackfillFactType t : values()) {
+            if (t.code.equalsIgnoreCase(code)) {
+                return t;
+            }
+        }
+        throw new IllegalArgumentException(
+                "Unknown backfill fact type: " + code
+                        + " (allowed: match, match-ban, match-participant-build)");
+    }
+}

--- a/app/src/main/java/com/mmrtr/lol/backfill/BackfillProgressService.java
+++ b/app/src/main/java/com/mmrtr/lol/backfill/BackfillProgressService.java
@@ -34,10 +34,10 @@ public class BackfillProgressService {
     private final JobExplorer jobExplorer;
 
     /**
-     * runId 로 가장 최근 JobExecution 의 진행 상황 조회.
+     * factType + runId 로 가장 최근 JobExecution 의 진행 상황 조회.
      */
-    public Optional<RunProgress> getProgressByRunId(String runId) {
-        return findLatestExecutionByRunId(runId).map(this::toProgress);
+    public Optional<RunProgress> getProgressByRunId(BackfillFactType factType, String runId) {
+        return findLatestExecutionByRunId(factType, runId).map(this::toProgress);
     }
 
     /**
@@ -48,13 +48,14 @@ public class BackfillProgressService {
     }
 
     /**
-     * 최근 실행된 N 개 run 요약.
+     * factType 별 최근 실행된 N 개 run 요약.
      */
-    public List<RunSummary> listRecentRuns(int limit) {
+    public List<RunSummary> listRecentRuns(BackfillFactType factType, int limit) {
         return jobExplorer
-                .getJobInstances(BackfillJobConfig.JOB_NAME, 0, Math.min(limit, RECENT_INSTANCES_LIMIT))
+                .getJobInstances(BackfillJobConfig.JOB_NAME, 0, RECENT_INSTANCES_LIMIT)
                 .stream()
                 .flatMap(ji -> jobExplorer.getJobExecutions(ji).stream())
+                .filter(je -> factType.code().equals(je.getJobParameters().getString("factType")))
                 .sorted(Comparator.comparing(JobExecution::getCreateTime).reversed())
                 .limit(limit)
                 .map(this::toSummary)
@@ -62,13 +63,14 @@ public class BackfillProgressService {
     }
 
     /**
-     * runId 의 가장 최근 JobExecution 조회 (재시작 / 파라미터 재사용 용도).
+     * factType + runId 의 가장 최근 JobExecution 조회 (재시작 / 파라미터 재사용 용도).
      */
-    public Optional<JobExecution> findLatestExecutionByRunId(String runId) {
+    public Optional<JobExecution> findLatestExecutionByRunId(BackfillFactType factType, String runId) {
         return jobExplorer
                 .getJobInstances(BackfillJobConfig.JOB_NAME, 0, RECENT_INSTANCES_LIMIT)
                 .stream()
                 .flatMap(ji -> jobExplorer.getJobExecutions(ji).stream())
+                .filter(je -> factType.code().equals(je.getJobParameters().getString("factType")))
                 .filter(je -> runId.equals(je.getJobParameters().getString("runId")))
                 .max(Comparator.comparing(JobExecution::getId));
     }
@@ -88,6 +90,7 @@ public class BackfillProgressService {
                 .sum();
 
         return new RunProgress(
+                exec.getJobParameters().getString("factType"),
                 exec.getJobParameters().getString("runId"),
                 exec.getId(),
                 exec.getStatus().name(),
@@ -110,6 +113,7 @@ public class BackfillProgressService {
                 .collect(Collectors.groupingBy(se -> se.getStatus().name(), Collectors.counting()));
 
         return new RunSummary(
+                exec.getJobParameters().getString("factType"),
                 exec.getJobParameters().getString("runId"),
                 exec.getId(),
                 exec.getStatus().name(),
@@ -123,7 +127,7 @@ public class BackfillProgressService {
 
     private boolean isChunkWorkerStep(StepExecution se) {
         // IdRangePartitioner 가 partition key 를 "chunk_<from>_<to>" 형태로 만듬.
-        // partition step 자체("mpBuildPartitionStep") / manifest step 은 제외.
+        // partition step / manifest step 은 제외.
         return se.getStepName() != null && se.getStepName().startsWith("chunk_");
     }
 
@@ -142,10 +146,8 @@ public class BackfillProgressService {
         );
     }
 
-    /**
-     * 단일 run 의 전체 진행 상황. chunks 는 startId 오름차순으로 정렬된 청크별 상세.
-     */
     public record RunProgress(
+            String factType,
             String runId,
             Long jobExecutionId,
             String jobStatus,
@@ -177,6 +179,7 @@ public class BackfillProgressService {
     }
 
     public record RunSummary(
+            String factType,
             String runId,
             Long jobExecutionId,
             String jobStatus,

--- a/app/src/main/java/com/mmrtr/lol/backfill/BackfillProperties.java
+++ b/app/src/main/java/com/mmrtr/lol/backfill/BackfillProperties.java
@@ -4,7 +4,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.util.List;
 
-@ConfigurationProperties(prefix = "lol.backfill.match-participant-build")
+@ConfigurationProperties(prefix = "lol.backfill")
 public record BackfillProperties(
         Range range,
         Chunk chunk,
@@ -21,6 +21,6 @@ public record BackfillProperties(
     public record Filter(int season, List<Integer> queueIds) {
     }
 
-    public record Gcs(String bucket, String prefix) {
+    public record Gcs(String bucket) {
     }
 }

--- a/app/src/main/java/com/mmrtr/lol/backfill/config/BackfillJobConfig.java
+++ b/app/src/main/java/com/mmrtr/lol/backfill/config/BackfillJobConfig.java
@@ -28,32 +28,32 @@ import org.springframework.transaction.PlatformTransactionManager;
 @RequiredArgsConstructor
 public class BackfillJobConfig {
 
-    public static final String JOB_NAME = "matchParticipantBuildBackfillJob";
-    private static final String PARTITION_STEP = "mpBuildPartitionStep";
-    private static final String CHUNK_STEP = "mpBuildChunkStep";
-    private static final String MANIFEST_STEP = "mpBuildManifestStep";
-    private static final String WORKER_PREFIX = "mp-build-backfill-";
+    public static final String JOB_NAME = "lolBackfillJob";
+    private static final String PARTITION_STEP = "backfillPartitionStep";
+    private static final String CHUNK_STEP = "backfillChunkStep";
+    private static final String MANIFEST_STEP = "backfillManifestStep";
+    private static final String WORKER_PREFIX = "lol-backfill-";
 
     private final JobRepository jobRepository;
     private final PlatformTransactionManager transactionManager;
 
     @Bean
-    public Job matchParticipantBuildBackfillJob(Step mpBuildPartitionStep, Step mpBuildManifestStep) {
+    public Job lolBackfillJob(Step backfillPartitionStep, Step backfillManifestStep) {
         return new JobBuilder(JOB_NAME, jobRepository)
-                .start(mpBuildPartitionStep)
-                .next(mpBuildManifestStep)
+                .start(backfillPartitionStep)
+                .next(backfillManifestStep)
                 .build();
     }
 
     @Bean
-    public Step mpBuildPartitionStep(
+    public Step backfillPartitionStep(
             IdRangePartitioner idRangePartitioner,
-            Step mpBuildChunkStep,
+            Step backfillChunkStep,
             TaskExecutor backfillTaskExecutor
     ) {
         TaskExecutorPartitionHandler handler = new TaskExecutorPartitionHandler();
         handler.setTaskExecutor(backfillTaskExecutor);
-        handler.setStep(mpBuildChunkStep);
+        handler.setStep(backfillChunkStep);
 
         return new StepBuilder(PARTITION_STEP, jobRepository)
                 .partitioner(CHUNK_STEP, idRangePartitioner)
@@ -62,14 +62,14 @@ public class BackfillJobConfig {
     }
 
     @Bean
-    public Step mpBuildChunkStep(ChunkExportTasklet chunkExportTasklet) {
+    public Step backfillChunkStep(ChunkExportTasklet chunkExportTasklet) {
         return new StepBuilder(CHUNK_STEP, jobRepository)
                 .tasklet(chunkExportTasklet, transactionManager)
                 .build();
     }
 
     @Bean
-    public Step mpBuildManifestStep(ManifestTasklet manifestTasklet) {
+    public Step backfillManifestStep(ManifestTasklet manifestTasklet) {
         return new StepBuilder(MANIFEST_STEP, jobRepository)
                 .tasklet(manifestTasklet, transactionManager)
                 .build();
@@ -107,7 +107,7 @@ public class BackfillJobConfig {
         launcherExecutor.setCorePoolSize(1);
         launcherExecutor.setMaxPoolSize(1);
         launcherExecutor.setQueueCapacity(4);
-        launcherExecutor.setThreadNamePrefix("mp-build-backfill-launcher-");
+        launcherExecutor.setThreadNamePrefix("lol-backfill-launcher-");
         launcherExecutor.initialize();
 
         TaskExecutorJobLauncher launcher = new TaskExecutorJobLauncher();

--- a/app/src/main/java/com/mmrtr/lol/backfill/sql/AggregationSql.java
+++ b/app/src/main/java/com/mmrtr/lol/backfill/sql/AggregationSql.java
@@ -1,32 +1,41 @@
 package com.mmrtr.lol.backfill.sql;
 
+import com.mmrtr.lol.backfill.BackfillFactType;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StreamUtils;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.EnumMap;
+import java.util.Map;
 
 @Component
 public class AggregationSql {
 
-    private static final String RESOURCE_PATH = "sql/match-participant-build-aggregation.sql";
-
-    private final String sql;
+    private final Map<BackfillFactType, String> cache;
 
     public AggregationSql() {
+        Map<BackfillFactType, String> map = new EnumMap<>(BackfillFactType.class);
+        for (BackfillFactType type : BackfillFactType.values()) {
+            map.put(type, load(type.sqlResourcePath()));
+        }
+        this.cache = map;
+    }
+
+    public String get(BackfillFactType factType) {
+        return cache.get(factType);
+    }
+
+    private static String load(String resourcePath) {
         try {
-            this.sql = StreamUtils.copyToString(
-                    new ClassPathResource(RESOURCE_PATH).getInputStream(),
+            return StreamUtils.copyToString(
+                    new ClassPathResource(resourcePath).getInputStream(),
                     StandardCharsets.UTF_8
             );
         } catch (IOException e) {
             throw new IllegalStateException(
-                    "Failed to load aggregation SQL resource: " + RESOURCE_PATH, e);
+                    "Failed to load aggregation SQL resource: " + resourcePath, e);
         }
-    }
-
-    public String get() {
-        return sql;
     }
 }

--- a/app/src/main/java/com/mmrtr/lol/backfill/tasklet/ChunkExportTasklet.java
+++ b/app/src/main/java/com/mmrtr/lol/backfill/tasklet/ChunkExportTasklet.java
@@ -1,6 +1,7 @@
 package com.mmrtr.lol.backfill.tasklet;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mmrtr.lol.backfill.BackfillFactType;
 import com.mmrtr.lol.backfill.BackfillProperties;
 import com.mmrtr.lol.backfill.gcs.GcsUploader;
 import com.mmrtr.lol.backfill.partition.IdRangePartitioner;
@@ -59,10 +60,14 @@ public class ChunkExportTasklet implements Tasklet {
     @Value("#{jobParameters['runId']}")
     private String runId;
 
+    @Value("#{jobParameters['factType']}")
+    private String factTypeCode;
+
     @Override
     public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
-        String objectName = buildObjectName();
-        long rowsWritten = exportToGcs(objectName);
+        BackfillFactType factType = BackfillFactType.fromCode(factTypeCode);
+        String objectName = buildObjectName(factType);
+        long rowsWritten = exportToGcs(objectName, factType);
 
         ExecutionContext stepCtx = chunkContext.getStepContext()
                 .getStepExecution()
@@ -77,12 +82,12 @@ public class ChunkExportTasklet implements Tasklet {
         return RepeatStatus.FINISHED;
     }
 
-    private String buildObjectName() {
+    private String buildObjectName(BackfillFactType factType) {
         return String.format("%s/%s/chunk_%012d_%012d.ndjson.gz",
-                properties.gcs().prefix(), runId, startId, endId);
+                factType.gcsPrefix(), runId, startId, endId);
     }
 
-    private long exportToGcs(String objectName) throws IOException {
+    private long exportToGcs(String objectName, BackfillFactType factType) throws IOException {
         NamedParameterJdbcTemplate jdbc = new NamedParameterJdbcTemplate(dataSource);
         jdbc.getJdbcTemplate().setFetchSize(properties.chunk().fetchSize());
 
@@ -100,7 +105,7 @@ public class ChunkExportTasklet implements Tasklet {
              BufferedWriter writer = new BufferedWriter(
                      new OutputStreamWriter(gzip, StandardCharsets.UTF_8))) {
 
-            jdbc.query(aggregationSql.get(), params, rs -> {
+            jdbc.query(aggregationSql.get(factType), params, rs -> {
                 try {
                     writer.write(rowToJson(rs));
                     writer.newLine();

--- a/app/src/main/java/com/mmrtr/lol/backfill/tasklet/ManifestTasklet.java
+++ b/app/src/main/java/com/mmrtr/lol/backfill/tasklet/ManifestTasklet.java
@@ -1,6 +1,7 @@
 package com.mmrtr.lol.backfill.tasklet;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mmrtr.lol.backfill.BackfillFactType;
 import com.mmrtr.lol.backfill.BackfillProperties;
 import com.mmrtr.lol.backfill.gcs.GcsUploader;
 import lombok.RequiredArgsConstructor;
@@ -45,11 +46,15 @@ public class ManifestTasklet implements Tasklet {
     @Value("#{jobParameters['runId']}")
     private String runId;
 
+    @Value("#{jobParameters['factType']}")
+    private String factTypeCode;
+
     @Value("#{stepExecution.jobExecution}")
     private JobExecution jobExecution;
 
     @Override
     public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+        BackfillFactType factType = BackfillFactType.fromCode(factTypeCode);
         List<Map<String, Object>> chunks = collectChunkEntries(jobExecution);
         long totalRows = chunks.stream()
                 .mapToLong(c -> ((Number) c.get("rows")).longValue())
@@ -57,6 +62,7 @@ public class ManifestTasklet implements Tasklet {
 
         Map<String, Object> manifest = Map.of(
                 "runId", runId,
+                "factType", factType.code(),
                 "schemaVersion", SCHEMA_VERSION,
                 "writtenAt", Instant.now().toString(),
                 "filter", Map.of(
@@ -75,7 +81,7 @@ public class ManifestTasklet implements Tasklet {
         byte[] content = objectMapper.writerWithDefaultPrettyPrinter()
                 .writeValueAsBytes(manifest);
         String objectName = String.format("%s/%s/_manifest.json",
-                properties.gcs().prefix(), runId);
+                factType.gcsPrefix(), runId);
         gcsUploader.uploadBytes(
                 properties.gcs().bucket(), objectName, content, "application/json");
 

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -42,17 +42,15 @@ lol:
     executors:
       enabled: ${LOL_VT_EXECUTORS_ENABLED:${LOL_VT_ENABLED:true}}
   backfill:
-    match-participant-build:
-      range:
-        start-id: ${BACKFILL_MP_BUILD_START_ID:1}
-        end-id: ${BACKFILL_MP_BUILD_END_ID:1}
-      chunk:
-        size: ${BACKFILL_MP_BUILD_CHUNK_SIZE:100000}
-        parallelism: ${BACKFILL_MP_BUILD_PARALLELISM:2}
-        fetch-size: ${BACKFILL_MP_BUILD_FETCH_SIZE:1000}
-      filter:
-        season: ${BACKFILL_MP_BUILD_SEASON:16}
-        queue-ids: ${BACKFILL_MP_BUILD_QUEUE_IDS:420,440}
-      gcs:
-        bucket: ${BACKFILL_MP_BUILD_GCS_BUCKET:}
-        prefix: ${BACKFILL_MP_BUILD_GCS_PREFIX:match_participant_build/backfill}
+    range:
+      start-id: ${BACKFILL_START_ID:1}
+      end-id: ${BACKFILL_END_ID:1}
+    chunk:
+      size: ${BACKFILL_CHUNK_SIZE:100000}
+      parallelism: ${BACKFILL_PARALLELISM:2}
+      fetch-size: ${BACKFILL_FETCH_SIZE:1000}
+    filter:
+      season: ${BACKFILL_SEASON:16}
+      queue-ids: ${BACKFILL_QUEUE_IDS:420,440}
+    gcs:
+      bucket: ${BACKFILL_GCS_BUCKET:}

--- a/docs/data/mv_champion_pick_stats.sql
+++ b/docs/data/mv_champion_pick_stats.sql
@@ -1,0 +1,47 @@
+-- ============================================================
+-- mart MV: 챔피언 × 라인 단위 픽/승 카운트
+--
+-- 차원: patch_version_int, platform_id, tier_bucket, individual_position, champion_id
+-- 행 단위: 차원 조합당 1행
+-- 측정값: pick_count, win_count, loss_count
+--
+-- base: metapick.lol_analytics.match_participant_fact (1행 = 1참가자)
+-- 갱신: BQ 자동 incremental refresh (30분 주기)
+--
+-- 다른 MV 와의 차이:
+--   - mv_champion_ban_stats: individual_position 차원 없음 (밴은 챔프 셀렉트 단계, 라인 미정)
+--   - mv_champion_item_build_stats: 동일한 라인 차원이지만 추가로 (item1,item2,item3) 슬롯 차원 보유
+--
+-- 분모(픽률 계산용 match_count):
+--   이 MV 에는 없음. mv_match_count_stats 와 조인해서 산출.
+--   pick_rate = pick_count / match_count
+-- ============================================================
+CREATE MATERIALIZED VIEW `metapick.lol_analytics.mv_champion_pick_stats`
+PARTITION BY RANGE_BUCKET(patch_version_int, GENERATE_ARRAY(1400, 2500, 1))
+CLUSTER BY platform_id, individual_position, champion_id, tier_bucket
+OPTIONS (
+  enable_refresh           = TRUE,
+  refresh_interval_minutes = 30,
+  description              = "패치 × 플랫폼 × 티어 × 라인 × 챔피언 픽/승/패 (자동 갱신 MV)"
+)
+AS
+SELECT
+  patch_version_int,
+  patch_version,
+  platform_id,
+  tier_bucket,
+  individual_position,
+  champion_id,
+  COUNT(*)         AS pick_count,
+  COUNTIF(win)     AS win_count,
+  COUNTIF(NOT win) AS loss_count
+FROM `metapick.lol_analytics.match_participant_fact`
+WHERE tier_bucket         IS NOT NULL                  -- 언랭 제외
+  AND individual_position IS NOT NULL                  -- 라인 미식별 제외
+GROUP BY
+  patch_version_int,
+  patch_version,
+  platform_id,
+  tier_bucket,
+  individual_position,
+  champion_id;

--- a/docs/data/query_champion_pick_stats.sql
+++ b/docs/data/query_champion_pick_stats.sql
@@ -1,0 +1,492 @@
+-- ============================================================
+-- 조회: 라인별 챔피언 픽/승/픽률/밴률/승률
+-- base: metapick.lol_analytics.mv_champion_pick_stats
+--       metapick.lol_analytics.mv_champion_ban_stats
+--       metapick.lol_analytics.mv_match_count_stats
+--
+-- 행 단위: (patch, platform, tier_bucket, individual_position, champion) × pick_count/win_count
+--
+-- 정의:
+--   - pick_rate = pick_count / match_count   — 라인별 다름
+--   - ban_rate  = ban_count  / match_count   — 라인 무관 (챔프 5라인 행 모두 같은 값)
+--   - win_rate  = win_count  / pick_count    — 라인별 다름
+--
+-- 다른 챔피언 통계 쿼리와 차이:
+--   - 픽/승은 individual_position 별로 분리되지만 밴은 챔프 단위로 합산해서 broadcasting
+--   - 분모(match_count) 는 patch×platform×tier 단일값이므로 CROSS JOIN
+-- ============================================================
+-- ─────────────────────────────────────────────────────────────
+-- [1] 단일 티어 — 라인별 챔피언 픽 Top 30 (라인당 상위)
+-- ─────────────────────────────────────────────────────────────
+WITH agg AS (
+  SELECT individual_position,
+    champion_id,
+    SUM(pick_count) AS pick_count,
+    SUM(win_count) AS win_count
+  FROM `metapick.lol_analytics.mv_champion_pick_stats`
+  WHERE patch_version_int = 1607 -- 패치 (예: 16.07)
+    AND platform_id = 'KR'
+    AND tier_bucket = 6000 -- DIAMOND
+  GROUP BY individual_position,
+    champion_id
+)
+SELECT individual_position,
+  champion_id,
+  pick_count,
+  win_count
+FROM agg QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY individual_position
+    ORDER BY pick_count DESC
+  ) <= 30
+ORDER BY individual_position,
+  pick_count DESC;
+-- ─────────────────────────────────────────────────────────────
+-- [2] 티어 범위 합산 — 다이아 이상(6000+) 라인별 챔피언 픽 Top 10
+-- ─────────────────────────────────────────────────────────────
+WITH agg AS (
+  SELECT individual_position,
+    champion_id,
+    SUM(pick_count) AS pick_count,
+    SUM(win_count) AS win_count
+  FROM `metapick.lol_analytics.mv_champion_pick_stats`
+  WHERE patch_version_int = 1607
+    AND platform_id = 'KR'
+    AND tier_bucket >= 6000 -- DIAMOND 이상
+  GROUP BY individual_position,
+    champion_id
+)
+SELECT individual_position,
+  champion_id,
+  pick_count,
+  win_count
+FROM agg QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY individual_position
+    ORDER BY pick_count DESC
+  ) <= 10
+ORDER BY individual_position,
+  pick_count DESC;
+-- ─────────────────────────────────────────────────────────────
+-- [3] 패치 범위 합산 — 최근 3패치(예: 1605~1607) 라인별 챔피언 픽 Top 10
+-- ─────────────────────────────────────────────────────────────
+WITH agg AS (
+  SELECT individual_position,
+    champion_id,
+    SUM(pick_count) AS pick_count,
+    SUM(win_count) AS win_count
+  FROM `metapick.lol_analytics.mv_champion_pick_stats`
+  WHERE patch_version_int BETWEEN 1605 AND 1607
+    AND platform_id = 'KR'
+    AND tier_bucket = 6000
+  GROUP BY individual_position,
+    champion_id
+)
+SELECT individual_position,
+  champion_id,
+  pick_count,
+  win_count
+FROM agg QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY individual_position
+    ORDER BY pick_count DESC
+  ) <= 10
+ORDER BY individual_position,
+  pick_count DESC;
+-- ─────────────────────────────────────────────────────────────
+-- [4] 픽률 — 단일 티어 — 라인별 Top 30
+-- pick_rate = pick_count / match_count
+-- 분모는 mv_match_count_stats 의 단일 행과 CROSS JOIN.
+-- ─────────────────────────────────────────────────────────────
+WITH picks AS (
+  SELECT individual_position,
+    champion_id,
+    SUM(pick_count) AS pick_count
+  FROM `metapick.lol_analytics.mv_champion_pick_stats`
+  WHERE patch_version_int = 1607
+    AND platform_id = 'KR'
+    AND tier_bucket = 6000
+  GROUP BY individual_position,
+    champion_id
+),
+matches AS (
+  SELECT match_count
+  FROM `metapick.lol_analytics.mv_match_count_stats`
+  WHERE patch_version_int = 1607
+    AND platform_id = 'KR'
+    AND tier_bucket = 6000
+)
+SELECT p.individual_position,
+  p.champion_id,
+  p.pick_count,
+  m.match_count,
+  SAFE_DIVIDE(p.pick_count, m.match_count) AS pick_rate
+FROM picks p
+  CROSS JOIN matches m QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY p.individual_position
+    ORDER BY p.pick_count DESC
+  ) <= 30
+ORDER BY individual_position,
+  pick_rate DESC;
+-- ─────────────────────────────────────────────────────────────
+-- [5] 승률 — 단일 티어 — 라인별 Top 30 (최소 픽 100 이상 필터)
+-- win_rate = win_count / pick_count
+-- 픽수가 적으면 분산 커서 신뢰도 떨어짐 → 최소 픽 컷 적용.
+-- ─────────────────────────────────────────────────────────────
+WITH agg AS (
+  SELECT individual_position,
+    champion_id,
+    SUM(pick_count) AS pick_count,
+    SUM(win_count) AS win_count
+  FROM `metapick.lol_analytics.mv_champion_pick_stats`
+  WHERE patch_version_int = 1607
+    AND platform_id = 'KR'
+    AND tier_bucket = 6000
+  GROUP BY individual_position,
+    champion_id
+)
+SELECT individual_position,
+  champion_id,
+  pick_count,
+  win_count,
+  SAFE_DIVIDE(win_count, pick_count) AS win_rate
+FROM agg
+WHERE pick_count >= 100 QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY individual_position
+    ORDER BY SAFE_DIVIDE(win_count, pick_count) DESC
+  ) <= 30
+ORDER BY individual_position,
+  win_rate DESC;
+-- ─────────────────────────────────────────────────────────────
+-- [6] 픽률 + 밴률 + 승률 통합 — 라인별 챔피언 종합 통계
+-- ban_rate 는 라인 무관 챔프 단위 → 5라인 행 모두 동일값으로 broadcasting.
+-- ─────────────────────────────────────────────────────────────
+WITH denom AS (
+  SELECT match_count
+  FROM `metapick.lol_analytics.mv_match_count_stats`
+  WHERE patch_version_int = 1607
+    AND platform_id = 'KR'
+    AND tier_bucket = 6000
+),
+ban_per_champ AS (
+  SELECT champion_id,
+    SUM(ban_count) AS ban_count
+  FROM `metapick.lol_analytics.mv_champion_ban_stats`
+  WHERE patch_version_int = 1607
+    AND platform_id = 'KR'
+    AND tier_bucket = 6000
+  GROUP BY champion_id
+),
+pick_per_lane AS (
+  SELECT individual_position,
+    champion_id,
+    SUM(pick_count) AS pick_count,
+    SUM(win_count) AS win_count
+  FROM `metapick.lol_analytics.mv_champion_pick_stats`
+  WHERE patch_version_int = 1607
+    AND platform_id = 'KR'
+    AND tier_bucket = 6000
+  GROUP BY individual_position,
+    champion_id
+)
+SELECT l.individual_position,
+  l.champion_id,
+  l.pick_count,
+  l.win_count,
+  COALESCE(b.ban_count, 0) AS ban_count,
+  d.match_count,
+  SAFE_DIVIDE(l.pick_count, d.match_count) AS pick_rate,
+  SAFE_DIVIDE(COALESCE(b.ban_count, 0), d.match_count) AS ban_rate,
+  SAFE_DIVIDE(l.win_count, l.pick_count) AS win_rate
+FROM pick_per_lane l
+  LEFT JOIN ban_per_champ b USING (champion_id)
+  CROSS JOIN denom d
+ORDER BY l.individual_position,
+  l.pick_count DESC;
+-- ─────────────────────────────────────────────────────────────
+-- [7] 픽률 + 밴률 + 승률 — 티어 범위 합산 (다이아 이상)
+-- ─────────────────────────────────────────────────────────────
+WITH denom AS (
+  SELECT SUM(match_count) AS match_count
+  FROM `metapick.lol_analytics.mv_match_count_stats`
+  WHERE patch_version_int = 1607
+    AND platform_id = 'KR'
+    AND tier_bucket >= 6000
+),
+ban_per_champ AS (
+  SELECT champion_id,
+    SUM(ban_count) AS ban_count
+  FROM `metapick.lol_analytics.mv_champion_ban_stats`
+  WHERE patch_version_int = 1607
+    AND platform_id = 'KR'
+    AND tier_bucket >= 6000
+  GROUP BY champion_id
+),
+pick_per_lane AS (
+  SELECT individual_position,
+    champion_id,
+    SUM(pick_count) AS pick_count,
+    SUM(win_count) AS win_count
+  FROM `metapick.lol_analytics.mv_champion_pick_stats`
+  WHERE patch_version_int = 1607
+    AND platform_id = 'KR'
+    AND tier_bucket >= 6000
+  GROUP BY individual_position,
+    champion_id
+)
+SELECT l.individual_position,
+  l.champion_id,
+  l.pick_count,
+  l.win_count,
+  COALESCE(b.ban_count, 0) AS ban_count,
+  d.match_count,
+  SAFE_DIVIDE(l.pick_count, d.match_count) AS pick_rate,
+  SAFE_DIVIDE(COALESCE(b.ban_count, 0), d.match_count) AS ban_rate,
+  SAFE_DIVIDE(l.win_count, l.pick_count) AS win_rate
+FROM pick_per_lane l
+  LEFT JOIN ban_per_champ b USING (champion_id)
+  CROSS JOIN denom d
+ORDER BY l.individual_position,
+  l.pick_count DESC;
+-- ─────────────────────────────────────────────────────────────
+-- [8] 특정 라인 — 픽률/밴률/승률 통합 Top 30
+-- 예: MIDDLE 라인.
+-- ─────────────────────────────────────────────────────────────
+WITH denom AS (
+  SELECT match_count
+  FROM `metapick.lol_analytics.mv_match_count_stats`
+  WHERE patch_version_int = 1607
+    AND platform_id = 'KR'
+    AND tier_bucket = 6000
+),
+ban_per_champ AS (
+  SELECT champion_id,
+    SUM(ban_count) AS ban_count
+  FROM `metapick.lol_analytics.mv_champion_ban_stats`
+  WHERE patch_version_int = 1607
+    AND platform_id = 'KR'
+    AND tier_bucket = 6000
+  GROUP BY champion_id
+),
+pick_lane AS (
+  SELECT champion_id,
+    SUM(pick_count) AS pick_count,
+    SUM(win_count) AS win_count
+  FROM `metapick.lol_analytics.mv_champion_pick_stats`
+  WHERE patch_version_int = 1607
+    AND platform_id = 'KR'
+    AND tier_bucket = 6000
+    AND individual_position = 'MIDDLE' -- 라인 고정
+  GROUP BY champion_id
+)
+SELECT l.champion_id,
+  l.pick_count,
+  l.win_count,
+  COALESCE(b.ban_count, 0) AS ban_count,
+  d.match_count,
+  SAFE_DIVIDE(l.pick_count, d.match_count) AS pick_rate,
+  SAFE_DIVIDE(COALESCE(b.ban_count, 0), d.match_count) AS ban_rate,
+  SAFE_DIVIDE(l.win_count, l.pick_count) AS win_rate
+FROM pick_lane l
+  LEFT JOIN ban_per_champ b USING (champion_id)
+  CROSS JOIN denom d
+ORDER BY pick_rate DESC
+LIMIT 30;
+-- ─────────────────────────────────────────────────────────────
+-- [9] 챔피언 티어 산출 — (patch, platform, tier_bucket, lane) 단일 segment
+--
+-- 점수 모델:
+--   wilson_wr   = 95% Wilson score lower bound — 픽수 적은 챔프 자동 강등
+--   presence    = pick_rate + ban_rate          — 라인 내 메타 영향력
+--   tier_score  = 0.6 × percentile(wilson_wr) + 0.4 × percentile(presence)
+--                 — 라인별 (PARTITION BY individual_position) percentile 산출
+--
+-- 티어 컷 (percentile of tier_score):
+--   S+ ≥ 0.97, S ≥ 0.90, A ≥ 0.75, B ≥ 0.50, C ≥ 0.20, D < 0.20
+--
+-- 픽수 컷:
+--   pick_count >= 20  — Wilson 이 보정해도 노이즈 방지용 최소 표본
+--
+-- tier_bucket >= 6000 — DIAMOND 이상 합산 segment.
+--   denom 은 여러 티어 행을 SUM, ban/pick 은 GROUP BY 로 합산.
+--
+-- 주의: BQ MV 는 window function 미지원이라 이 query 는 MV 화 불가.
+--       자주 쓰면 일반 VIEW 또는 scheduled query 로 승격.
+-- ─────────────────────────────────────────────────────────────
+WITH denom AS (
+  SELECT SUM(match_count) AS match_count
+  FROM `metapick.lol_analytics.mv_match_count_stats`
+  WHERE patch_version_int = 1607
+    AND platform_id = 'KR'
+    AND tier_bucket >= 6000
+),
+ban_per_champ AS (
+  SELECT champion_id,
+    SUM(ban_count) AS ban_count
+  FROM `metapick.lol_analytics.mv_champion_ban_stats`
+  WHERE patch_version_int = 1607
+    AND platform_id = 'KR'
+    AND tier_bucket >= 6000
+  GROUP BY champion_id
+),
+pick_per_lane AS (
+  SELECT individual_position,
+    champion_id,
+    SUM(pick_count) AS pick_count,
+    SUM(win_count) AS win_count
+  FROM `metapick.lol_analytics.mv_champion_pick_stats` d
+  WHERE patch_version_int = 1607
+    AND platform_id = 'KR'
+    AND tier_bucket >= 6000
+  GROUP BY individual_position,
+    champion_id
+),
+base AS (
+  SELECT l.individual_position,
+    l.champion_id,
+    l.pick_count,
+    l.win_count,
+    COALESCE(b.ban_count, 0) AS ban_count,
+    d.match_count,
+    SAFE_DIVIDE(l.pick_count, d.match_count) AS pick_rate,
+    SAFE_DIVIDE(COALESCE(b.ban_count, 0), d.match_count) AS ban_rate,
+    SAFE_DIVIDE(
+      l.pick_count + COALESCE(b.ban_count, 0),
+      d.match_count
+    ) AS presence,
+    SAFE_DIVIDE(l.win_count, l.pick_count) AS win_rate,
+    -- Wilson score 95% lower bound (z = 1.96)
+    SAFE_DIVIDE(
+      (l.win_count + 1.96 * 1.96 / 2) / l.pick_count - 1.96 * SQRT(
+        SAFE_DIVIDE(
+          l.win_count * (l.pick_count - l.win_count),
+          l.pick_count
+        ) + 1.96 * 1.96 / 4
+      ) / l.pick_count,
+      1 + 1.96 * 1.96 / l.pick_count
+    ) AS wilson_wr
+  FROM pick_per_lane l
+    LEFT JOIN ban_per_champ b USING (champion_id)
+    CROSS JOIN denom d
+  WHERE l.pick_count >= 20
+),
+ranked AS (
+  SELECT *,
+    PERCENT_RANK() OVER (
+      PARTITION BY individual_position
+      ORDER BY wilson_wr
+    ) AS pct_wilson_wr,
+    PERCENT_RANK() OVER (
+      PARTITION BY individual_position
+      ORDER BY presence
+    ) AS pct_presence
+  FROM base
+)
+SELECT individual_position,
+  champion_id,
+  pick_count,
+  win_count,
+  ban_count,
+  match_count,
+  ROUND(pick_rate * 100, 2) AS pick_rate_pct,
+  ROUND(ban_rate * 100, 2) AS ban_rate_pct,
+  ROUND(win_rate * 100, 2) AS win_rate_pct,
+  ROUND(wilson_wr * 100, 2) AS wilson_wr_pct,
+  ROUND(presence * 100, 2) AS presence_pct,
+  ROUND(0.6 * pct_wilson_wr + 0.4 * pct_presence, 4) AS tier_score,
+  CASE
+    WHEN 0.6 * pct_wilson_wr + 0.4 * pct_presence >= 0.97 THEN 'S+'
+    WHEN 0.6 * pct_wilson_wr + 0.4 * pct_presence >= 0.90 THEN 'S'
+    WHEN 0.6 * pct_wilson_wr + 0.4 * pct_presence >= 0.75 THEN 'A'
+    WHEN 0.6 * pct_wilson_wr + 0.4 * pct_presence >= 0.50 THEN 'B'
+    WHEN 0.6 * pct_wilson_wr + 0.4 * pct_presence >= 0.20 THEN 'C'
+    ELSE 'D'
+  END AS tier
+FROM ranked
+ORDER BY individual_position,
+  tier_score DESC;
+-- ─────────────────────────────────────────────────────────────
+-- [10] 챔피언 티어 — 특정 라인만 (예: MIDDLE)
+-- 출력 줄 수가 적어 결과 검토 / op.gg 비교용으로 사용.
+-- ─────────────────────────────────────────────────────────────
+WITH denom AS (
+  SELECT match_count
+  FROM `metapick.lol_analytics.mv_match_count_stats`
+  WHERE patch_version_int = 1607
+    AND platform_id = 'KR'
+    AND tier_bucket = 6000
+),
+ban_per_champ AS (
+  SELECT champion_id,
+    SUM(ban_count) AS ban_count
+  FROM `metapick.lol_analytics.mv_champion_ban_stats`
+  WHERE patch_version_int = 1607
+    AND platform_id = 'KR'
+    AND tier_bucket = 6000
+  GROUP BY champion_id
+),
+pick_lane AS (
+  SELECT champion_id,
+    SUM(pick_count) AS pick_count,
+    SUM(win_count) AS win_count
+  FROM `metapick.lol_analytics.mv_champion_pick_stats`
+  WHERE patch_version_int = 1607
+    AND platform_id = 'KR'
+    AND tier_bucket = 6000
+    AND individual_position = 'MIDDLE' -- 라인 고정
+  GROUP BY champion_id
+),
+base AS (
+  SELECT l.champion_id,
+    l.pick_count,
+    l.win_count,
+    COALESCE(b.ban_count, 0) AS ban_count,
+    d.match_count,
+    SAFE_DIVIDE(l.pick_count, d.match_count) AS pick_rate,
+    SAFE_DIVIDE(COALESCE(b.ban_count, 0), d.match_count) AS ban_rate,
+    SAFE_DIVIDE(
+      l.pick_count + COALESCE(b.ban_count, 0),
+      d.match_count
+    ) AS presence,
+    SAFE_DIVIDE(l.win_count, l.pick_count) AS win_rate,
+    SAFE_DIVIDE(
+      (l.win_count + 1.96 * 1.96 / 2) / l.pick_count - 1.96 * SQRT(
+        SAFE_DIVIDE(
+          l.win_count * (l.pick_count - l.win_count),
+          l.pick_count
+        ) + 1.96 * 1.96 / 4
+      ) / l.pick_count,
+      1 + 1.96 * 1.96 / l.pick_count
+    ) AS wilson_wr
+  FROM pick_lane l
+    LEFT JOIN ban_per_champ b USING (champion_id)
+    CROSS JOIN denom d
+  WHERE l.pick_count >= 20
+),
+ranked AS (
+  SELECT *,
+    PERCENT_RANK() OVER (
+      ORDER BY wilson_wr
+    ) AS pct_wilson_wr,
+    PERCENT_RANK() OVER (
+      ORDER BY presence
+    ) AS pct_presence
+  FROM base
+)
+SELECT champion_id,
+  pick_count,
+  win_count,
+  ban_count,
+  ROUND(pick_rate * 100, 2) AS pick_rate_pct,
+  ROUND(ban_rate * 100, 2) AS ban_rate_pct,
+  ROUND(win_rate * 100, 2) AS win_rate_pct,
+  ROUND(wilson_wr * 100, 2) AS wilson_wr_pct,
+  ROUND(presence * 100, 2) AS presence_pct,
+  ROUND(0.6 * pct_wilson_wr + 0.4 * pct_presence, 4) AS tier_score,
+  CASE
+    WHEN 0.6 * pct_wilson_wr + 0.4 * pct_presence >= 0.97 THEN 'S+'
+    WHEN 0.6 * pct_wilson_wr + 0.4 * pct_presence >= 0.90 THEN 'S'
+    WHEN 0.6 * pct_wilson_wr + 0.4 * pct_presence >= 0.75 THEN 'A'
+    WHEN 0.6 * pct_wilson_wr + 0.4 * pct_presence >= 0.50 THEN 'B'
+    WHEN 0.6 * pct_wilson_wr + 0.4 * pct_presence >= 0.20 THEN 'C'
+    ELSE 'D'
+  END AS tier
+FROM ranked
+ORDER BY tier_score DESC;


### PR DESCRIPTION
## Summary

- 백필 잡을 `BackfillFactType` enum + JobParameter 기반 Strategy 패턴으로 일반화. 동일 잡으로 `match` / `match-ban` / `match-participant-build` 모두 처리 (SQL/GCS prefix 만 디스패치).
- Endpoint: `POST /internal/backfill/{factType}/run` 형태로 통합. 기존 환경변수 prefix 도 `BACKFILL_MP_BUILD_*` → `BACKFILL_*` 로 정리.
- BigQuery MV `mv_champion_pick_stats` (라인×챔피언 픽/승 카운트, 30분 자동 refresh) 추가.
- 라인별 픽률·승률·밴률·티어 계산 쿼리 모음 추가 (`docs/data/query_champion_pick_stats.sql`). 티어는 Wilson score 95% 하한 + percent_rank 합성 점수 기반.

## Test plan

- [x] `./gradlew :app:check` 통과 (compile + Checkstyle + tests)
- [ ] 운영 환경변수 마이그레이션 확인 (`BACKFILL_GCS_BUCKET`, `BACKFILL_PARALLELISM`, `BACKFILL_FETCH_SIZE` 등)
- [ ] `POST /internal/backfill/match/run` 1청크 검증 → GCS 업로드 → `bq load` → fact 적재 확인
- [ ] `POST /internal/backfill/match-ban/run` 동일 검증
- [ ] `POST /internal/backfill/match-participant-build/run` 동일 검증
- [ ] BQ 콘솔에서 `mv_champion_pick_stats` 자동 refresh 확인 (`INFORMATION_SCHEMA.MATERIALIZED_VIEWS`)
- [ ] `query_champion_pick_stats.sql` 의 픽률/승률/티어 쿼리 결과 sanity check