### PR TITLE
[MP-75] refactor: jacoco 커버리지 리포트 워크플로우 제거

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,21 +31,6 @@ jobs:
         if: always()
         run: ./gradlew checkstyleMain --no-daemon
 
-      - name: Generate JaCoCo Report
-        if: always()
-        run: ./gradlew jacocoTestReport --no-daemon
-
-      - name: Add Coverage to PR
-        if: github.event_name == 'pull_request'
-        uses: madrapps/jacoco-report@v1.7.2
-        with:
-          paths: '**/build/reports/jacoco/test/jacocoTestReport.xml'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          min-coverage-overall: 0
-          min-coverage-changed-files: 0
-          title: 'Code Coverage Report'
-          update-comment: true
-
   notify:
     name: Slack Notification
     runs-on: ubuntu-latest

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,6 @@ subprojects {
     apply plugin: 'java-library'
     apply plugin: 'org.springframework.boot'
     apply plugin: 'io.spring.dependency-management'
-    apply plugin: 'jacoco'
     apply plugin: 'checkstyle'
 
     java {
@@ -59,22 +58,8 @@ subprojects {
         enabled = false
     }
 
-    jacoco {
-        toolVersion = "0.8.12"
-    }
-
     tasks.named('test') {
         useJUnitPlatform()
-        finalizedBy jacocoTestReport
-    }
-
-    jacocoTestReport {
-        dependsOn test
-        reports {
-            xml.required = true
-            html.required = true
-            csv.required = false
-        }
     }
 
     tasks.withType(JavaCompile).configureEach {


### PR DESCRIPTION
## Summary
- jacoco 커버리지 리포트 + PR 코멘트 워크플로우 제거 (build.gradle plugin/설정 블록 + ci.yml 2 스텝)
- 외부 동작 보존 — bootJar / checkstyleMain / Slack 알림 / permissions:pull-requests:write 그대로

## Changes
- `build.gradle` — `apply plugin: 'jacoco'` / `jacoco{}` / `finalizedBy jacocoTestReport` / `jacocoTestReport{}` 4개 영역 삭제
- `.github/workflows/ci.yml` — `Generate JaCoCo Report`, `Add Coverage to PR` (madrapps/jacoco-report) 2 스텝 삭제

## Test plan
- [ ] `./gradlew :app:bootJar --no-daemon` 통과 (로컬 검증 완료)
- [ ] `./gradlew checkstyleMain --no-daemon` 통과 (로컬 검증 완료)
- [ ] CI: Build & Test / Checkstyle / Slack Notification 모두 success

Closes MP-75

🤖 Generated by Padosol
