### PR TITLE
fix(MP-89): review round 1 후속 — RiotRateLimitException retry + InterruptedException 전파 + 시나리오 8

### DIFF
--- a/infra/riot-client/src/main/java/com/mmrtr/lol/infra/riot/interceptor/RetryInterceptor.java
+++ b/infra/riot-client/src/main/java/com/mmrtr/lol/infra/riot/interceptor/RetryInterceptor.java
@@ -54,7 +54,7 @@ public class RetryInterceptor implements ClientHttpRequestInterceptor {
 
                 recordResponse(status, host);
 
-                if (status.value() == HttpStatus.TOO_MANY_REQUESTS.value()) {
+                if (HttpStatus.TOO_MANY_REQUESTS.equals(status)) {
                     Duration retryAfter = parseRetryAfter(response.getHeaders().getFirst("Retry-After"));
                     if (attempt == MAX_ATTEMPTS) {
                         closeQuietly(response);
@@ -65,7 +65,7 @@ public class RetryInterceptor implements ClientHttpRequestInterceptor {
                     log.warn("Riot 429 — attempt {}/{}, Retry-After={}s, sleep base={}ms",
                             attempt, MAX_ATTEMPTS, retryAfter.toSeconds(), base);
                     closeQuietly(response);
-                    sleepWithBackoff(jitter(cap(base)));
+                    sleepOrAbort(jitter(cap(base)));
                     continue;
                 }
 
@@ -76,7 +76,7 @@ public class RetryInterceptor implements ClientHttpRequestInterceptor {
                     }
                     log.warn("Riot 5xx — attempt {}/{}, status={}", attempt, MAX_ATTEMPTS, status.value());
                     closeQuietly(response);
-                    sleepWithBackoff(jitter(cap(exponentialBackoffMs(attempt))));
+                    sleepOrAbort(jitter(cap(exponentialBackoffMs(attempt))));
                     continue;
                 }
 
@@ -84,13 +84,29 @@ public class RetryInterceptor implements ClientHttpRequestInterceptor {
                     recordSuccessAfterRetry();
                 }
                 return response;
+            } catch (RiotRateLimitException e) {
+                if (attempt == MAX_ATTEMPTS) {
+                    recordExhausted();
+                    throw e;
+                }
+                Duration retryAfter = e.getRetryAfter();
+                long base = (retryAfter == null || retryAfter.isZero())
+                        ? exponentialBackoffMs(attempt)
+                        : retryAfter.toMillis();
+                log.warn("Riot RiotRateLimitException — attempt {}/{}, retryAfter={}ms, base={}ms",
+                        attempt, MAX_ATTEMPTS,
+                        retryAfter == null ? -1L : retryAfter.toMillis(), base);
+                sleepOrAbort(jitter(cap(base)));
             } catch (IOException e) {
+                if (e.getCause() instanceof InterruptedException) {
+                    throw e;
+                }
                 if (attempt == MAX_ATTEMPTS) {
                     recordExhausted();
                     throw e;
                 }
                 log.warn("Riot IOException — attempt {}/{}: {}", attempt, MAX_ATTEMPTS, e.getMessage());
-                sleepWithBackoff(jitter(cap(exponentialBackoffMs(attempt))));
+                sleepOrAbort(jitter(cap(exponentialBackoffMs(attempt))));
             }
         }
         throw new IllegalStateException("RetryInterceptor loop exited without resolution");
@@ -126,7 +142,7 @@ public class RetryInterceptor implements ClientHttpRequestInterceptor {
         return Math.max(0L, (long) (ms + random));
     }
 
-    private void sleepWithBackoff(long ms) {
+    private void sleepOrAbort(long ms) throws IOException {
         Timer.Sample sample = Timer.start(meterRegistry);
         try {
             if (ms > 0L) {
@@ -134,6 +150,7 @@ public class RetryInterceptor implements ClientHttpRequestInterceptor {
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+            throw new IOException("RetryInterceptor backoff interrupted", e);
         } finally {
             sample.stop(meterRegistry.timer("riot.api.retry.backoff"));
         }

--- a/infra/riot-client/src/test/java/com/mmrtr/lol/infra/riot/interceptor/RetryInterceptorTest.java
+++ b/infra/riot-client/src/test/java/com/mmrtr/lol/infra/riot/interceptor/RetryInterceptorTest.java
@@ -2,19 +2,32 @@ package com.mmrtr.lol.infra.riot.interceptor;
 
 import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.mmrtr.lol.infra.riot.exception.RiotRateLimitException;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.boot.logging.LogLevel;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
 import java.net.http.HttpClient;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
@@ -33,7 +46,10 @@ class RetryInterceptorTest {
 
     private SimpleMeterRegistry meterRegistry;
     private List<Long> sleeps;
+    private RetryInterceptor retryInterceptor;
+    private JdkClientHttpRequestFactory factory;
     private RestClient restClient;
+    private String host;
 
     @BeforeEach
     void setUp() {
@@ -41,12 +57,12 @@ class RetryInterceptorTest {
         meterRegistry = new SimpleMeterRegistry();
         sleeps = new ArrayList<>();
         RetryInterceptor.Sleeper sleeper = (long ms) -> sleeps.add(ms);
-        RetryInterceptor retryInterceptor = new RetryInterceptor(meterRegistry, sleeper);
+        retryInterceptor = new RetryInterceptor(meterRegistry, sleeper);
 
         HttpClient httpClient = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(2))
                 .build();
-        JdkClientHttpRequestFactory factory = new JdkClientHttpRequestFactory(httpClient);
+        factory = new JdkClientHttpRequestFactory(httpClient);
         factory.setReadTimeout(Duration.ofMillis(500));
 
         restClient = RestClient.builder()
@@ -54,6 +70,8 @@ class RetryInterceptorTest {
                 .baseUrl(wm.baseUrl())
                 .requestInterceptor(retryInterceptor)
                 .build();
+
+        host = URI.create(wm.baseUrl()).getHost();
     }
 
     @Test
@@ -110,7 +128,7 @@ class RetryInterceptorTest {
     }
 
     @Test
-    @DisplayName("시나리오 4: 5xx → 5xx → 200 (재시도 2회)")
+    @DisplayName("시나리오 4: 5xx → 5xx → 200 (재시도 2회) + responses counter 누적 확인")
     void scenario4_5xx_5xx_200() {
         wm.stubFor(get(urlEqualTo("/x")).inScenario("c")
                 .whenScenarioStateIs("Started")
@@ -131,6 +149,11 @@ class RetryInterceptorTest {
         assertThat(sleeps).hasSize(2);
         assertThat(sleeps.get(0)).isBetween(375L, 625L);
         assertThat(sleeps.get(1)).isBetween(750L, 1250L);
+        // riot.api.responses counter 는 매 시도마다 누적
+        assertThat(meterRegistry.counter("riot.api.responses", "status", "500", "host", host).count())
+                .isEqualTo(2.0);
+        assertThat(meterRegistry.counter("riot.api.responses", "status", "200", "host", host).count())
+                .isEqualTo(1.0);
     }
 
     @Test
@@ -160,7 +183,6 @@ class RetryInterceptorTest {
         assertThat(body).isEqualTo("ok");
         assertThat(sleeps).hasSize(1);
         assertThat(sleeps.get(0)).isBetween(11_250L, 18_750L);
-        assertThat(sleeps.get(0)).isLessThan(60_000L);
     }
 
     @Test
@@ -181,5 +203,102 @@ class RetryInterceptorTest {
         assertThat(sleeps).hasSize(1);
         assertThat(meterRegistry.counter("riot.api.retry.attempts", "outcome", "success").count())
                 .isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("시나리오 8: 로컬 limiter (RiotRateLimitException) → retry → 성공 (unit-level)")
+    void scenario8_local_limiter_then_200() throws IOException {
+        // Spring InterceptingRequestExecution 은 single-pass iterator 라 RestClient chain 안의
+        // fake interceptor 가 retry 두번째 시도에 다시 호출되지 않는다 (production 의 RateLimitInterceptor
+        // 도 동일한 한계 — 기존 spring-retry 시절부터 존재). 따라서 시나리오 8 은 RetryInterceptor 의
+        // RiotRateLimitException catch + retry 동작을 unit-level (ClientHttpRequestExecution lambda) 로 검증.
+        HttpRequest request = new TestHttpRequest(URI.create("http://example.com/x"), HttpMethod.GET);
+        ClientHttpResponse okResponse = new TestClientHttpResponse(HttpStatus.OK, "ok");
+
+        AtomicInteger calls = new AtomicInteger(0);
+        ClientHttpRequestExecution execution = (req, body) -> {
+            if (calls.incrementAndGet() == 1) {
+                throw new RiotRateLimitException(
+                        Duration.ZERO, HttpStatus.TOO_MANY_REQUESTS, "Local limiter exhausted", LogLevel.WARN);
+            }
+            return okResponse;
+        };
+
+        ClientHttpResponse response = retryInterceptor.intercept(request, new byte[0], execution);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(calls.get()).isEqualTo(2);
+        assertThat(sleeps).hasSize(1);
+        // RiotRateLimitException(Duration.ZERO) → exp backoff (INITIAL=500ms ± 25%)
+        assertThat(sleeps.get(0)).isBetween(375L, 625L);
+        assertThat(meterRegistry.counter("riot.api.retry.attempts", "outcome", "success").count())
+                .isEqualTo(1.0);
+    }
+
+    private static final class TestHttpRequest implements HttpRequest {
+        private final URI uri;
+        private final HttpMethod method;
+        private final HttpHeaders headers = new HttpHeaders();
+
+        TestHttpRequest(URI uri, HttpMethod method) {
+            this.uri = uri;
+            this.method = method;
+        }
+
+        @Override
+        public HttpMethod getMethod() {
+            return method;
+        }
+
+        @Override
+        public URI getURI() {
+            return uri;
+        }
+
+        @Override
+        public HttpHeaders getHeaders() {
+            return headers;
+        }
+
+        @Override
+        public java.util.Map<String, Object> getAttributes() {
+            return java.util.Map.of();
+        }
+    }
+
+    private static final class TestClientHttpResponse implements ClientHttpResponse {
+        private final HttpStatus status;
+        private final HttpHeaders headers = new HttpHeaders();
+        private final byte[] body;
+
+        TestClientHttpResponse(HttpStatus status, String body) {
+            this.status = status;
+            this.body = body.getBytes();
+        }
+
+        @Override
+        public HttpStatus getStatusCode() {
+            return status;
+        }
+
+        @Override
+        public String getStatusText() {
+            return status.getReasonPhrase();
+        }
+
+        @Override
+        public void close() {
+            // no-op
+        }
+
+        @Override
+        public InputStream getBody() {
+            return new ByteArrayInputStream(body);
+        }
+
+        @Override
+        public HttpHeaders getHeaders() {
+            return headers;
+        }
     }
 }


### PR DESCRIPTION
## Summary

PR #60 머지 후 누락된 review round 1 수정 반영. PR #60 의 reviewer needs-changes (merge blocker — Linear 흐름도의 RiotRateLimitException retry 갭) 가 머지 직전 도착했으나, PR head=df77534 가 그 수정 없이 develop 으로 머지됨. 본 PR 은 누락분을 develop 에 보완.

Refs MP-89 (post-merge round 1 fix for #60)

## 배경

- 05:17 UTC: reviewer 가 PR #60 에 needs-changes 답신
- 05:23 UTC: PR #60 (head=df77534) merged
- 05:24 UTC: 워커가 round 1 수정 commit (`052cb60`) 을 `fix/MP-89` 에 push — 이미 PR closed/merged 상태라 GitHub Actions sync 트리거 안 함
- 결정 (leader): 옵션 (a) 채택 — 새 브랜치 `fix/MP-89-round-1` 를 `develop` 기준으로 만들고 round 1 수정 cherry-pick 후 별도 PR 로 머지

## 변경 요약 (PR #60 의 round 1 review 본문 기준)

### Merge blocker

- `RetryInterceptor` 에 `catch (RiotRateLimitException e)` 분기 추가 — Linear 본문 흐름도 "RetryInterceptor 가장 바깥 ← RiotRateLimitException / RiotServerException / IOException 잡아 backoff+재시도" 와 일치
  - `e.getRetryAfter()` 이 `Duration.ZERO` 가 아니면 그 값 사용 (HTTP 429 경로와 같은 처리 — cap=15s, jitter ±25%)
  - `Duration.ZERO` 면 attempt 기반 exponential backoff + jitter
  - `attempt == MAX_ATTEMPTS` 면 rethrow (exhausted)
  - 메트릭: `riot.api.retry.attempts{outcome=success|exhausted}`, `riot.api.retry.backoff` 모두 HTTP 429 경로와 동일하게 기록

### Non-blocking 코멘트 처리

1. `status.value() == HttpStatus.TOO_MANY_REQUESTS.value()` → `HttpStatus.TOO_MANY_REQUESTS.equals(status)` 로 교체
2. `sleepWithBackoff` → `sleepOrAbort` 로 rename: `InterruptedException` 시 `Thread.currentThread().interrupt()` 후 `IOException(cause=InterruptedException)` 으로 wrap → caller 에 전파. `catch (IOException)` 에서 `cause instanceof InterruptedException` 확인 후 즉시 rethrow (graceful shutdown 중 추가 통신 차단)
3. `RetryInterceptorTest` 시나리오 6 의 잉여 한 줄 (`assertThat(sleeps.get(0)).isLessThan(60_000L)`) 삭제 — 위의 `isBetween(11_250L, 18_750L)` 가 이미 cap 검증
4. PR 본문에 `riot.api.responses` counter 매 시도마다 누적 명시 (Grafana 쿼리 시 'request 1건 = counter 1건' 가정 금지)

### Test gap 보강

- 시나리오 4 (`5xx → 5xx → 200`) 에 `riot.api.responses{status,host}` counter 누적 검증 추가 — `status=500 count==2`, `status=200 count==1`
- 시나리오 8 신규 — 로컬 limiter (RiotRateLimitException) 시뮬 후 retry → 200 검증 (unit-level)
  - **unit-level 인 이유**: Spring `InterceptingRequestExecution` 은 single-pass iterator 라 RestClient chain 안의 fake interceptor 가 retry 두번째 시도에 다시 호출되지 않는다. production 의 `RateLimitInterceptor` 도 retry 두번째 시도부터 우회됨 — 기존 spring-retry 시절부터 존재하는 한계 (후속 phase 후보로 leader 에 mention 됨)
  - 구현: `ClientHttpRequestExecution` lambda + `TestHttpRequest` / `TestClientHttpResponse` inner classes. `retryInterceptor.intercept(req, body, execution)` 직접 호출
  - 검증: `calls.get() == 2`, `sleeps ∈ [375, 625] ms` (Duration.ZERO → exp backoff INITIAL=500ms ± 25%), `riot.api.retry.attempts{outcome=success} += 1`

## WireMock 8 시나리오 결과

`./gradlew :infra:riot-client:test` (`tests=8 failures=0 errors=0 time=0.629s`):

| # | 시나리오 | 결과 |
| --- | --- | --- |
| 1 | 200 즉시 → retry 0회 | PASS |
| 2 | 429 `Retry-After: 1` → 1s sleep → 200 | PASS (sleep ∈ [750, 1250] ms) |
| 3 | 429 헤더 없음 → exp backoff → 200 | PASS (sleep ∈ [375, 625] ms) |
| 4 | 5xx → 5xx → 200 + responses counter 누적 | PASS (status=500 count==2, status=200 count==1) |
| 5 | 영구 4xx (400) → 즉시 throw, retry 0회 | PASS |
| 6 | `Retry-After: 60` → 15s 캡 적용 | PASS (sleep ∈ [11_250, 18_750] ms) |
| 7 | IOException (connection reset) → retry → 성공 | PASS |
| 8 | 로컬 limiter (RiotRateLimitException) → retry → 성공 (unit-level) | PASS (calls==2, success counter += 1) |

## `./gradlew :infra:riot-client:check` 결과

```
> Task :infra:riot-client:checkstyleMain
> Task :infra:riot-client:compileTestJava
> Task :infra:riot-client:test
> Task :infra:riot-client:check
BUILD SUCCESSFUL
```

Checkstyle + 8 시나리오 단위테스트 통과.

## Follow-up 후보 (별도 mention)

본 PR 범위 아님. REPORT 단계에서 orch 로 송신 예정:

- Spring `InterceptingRequestExecution` 의 single-pass iterator 한계로 `RetryInterceptor` 가 retry 두번째 시도부터 chain 의 안쪽 interceptor (`RateLimitInterceptor` 등) 를 우회. 후속 phase 후보 — `RetryInterceptor` 위치 재배치 또는 RestClient 호출 자체를 wrap 하는 retry 데코레이터.

## Test plan

- [x] `./gradlew :infra:riot-client:check` 통과
- [x] WireMock 8 시나리오 모두 green
- [ ] 운영 환경 배포 후 Grafana `riot.api.retry.attempts{outcome=exhausted}` 메트릭 추세 모니터링

🤖 Generated by Padosol