### PR TITLE
feat(match): cache invalidation + bounded queue + DLX for matchId

### DIFF
--- a/core/domain/src/main/java/com/mmrtr/lol/domain/match/application/port/MatchCacheEvictPort.java
+++ b/core/domain/src/main/java/com/mmrtr/lol/domain/match/application/port/MatchCacheEvictPort.java
@@ -1,0 +1,20 @@
+package com.mmrtr.lol.domain.match.application.port;
+
+import java.util.Set;
+
+/**
+ * lol-server 가 보유한 매치 관련 캐시를 무효화하기 위한 outbound port.
+ * <p>
+ * lol-repository 가 새 매치를 저장한 직후 호출되어, 사용자가 최신 매치를
+ * 즉시 볼 수 있도록 한다. 호출은 best-effort 이며 실패해도 저장 트랜잭션은
+ * 영향을 받지 않는다.
+ */
+public interface MatchCacheEvictPort {
+
+    /**
+     * 주어진 puuid 들의 매치 리스트 캐시(`match:list:v1:{puuid}:*`) 를 모두 제거한다.
+     *
+     * @param puuids 영향을 받은 참가자 puuid 집합
+     */
+    void evictByPuuids(Set<String> puuids);
+}

--- a/infra/rabbitmq/src/main/java/com/mmrtr/lol/infra/rabbitmq/config/RabbitMqBinding.java
+++ b/infra/rabbitmq/src/main/java/com/mmrtr/lol/infra/rabbitmq/config/RabbitMqBinding.java
@@ -9,6 +9,7 @@ public enum RabbitMqBinding {
     SUMMONER("mmrtr.exchange", "mmrtr.key", Queue.SUMMONER),
     SUMMONER_DLX("summoner.dlx.exchange", "deadLetter", Queue.SUMMONER_DLX),
     MATCH_ID("mmrtr.matchId.exchange", "mmrtr.routingkey.matchId", Queue.MATCH_ID),
+    MATCH_ID_DLX("matchId.dlx.exchange", "deadLetter", Queue.MATCH_ID_DLX),
     RENEWAL_MATCH_FIND("renewal.topic.exchange", "renewal.match.find", Queue.RENEWAL_MATCH_FIND);
 
     private final String exchange;
@@ -19,6 +20,7 @@ public enum RabbitMqBinding {
         public static final String SUMMONER = "mmrtr.summoner";
         public static final String SUMMONER_DLX = "mmrtr.summoner.dlx";
         public static final String MATCH_ID = "mmrtr.matchId";
+        public static final String MATCH_ID_DLX = "mmrtr.matchId.dlx";
         public static final String RENEWAL_MATCH_FIND = "renewal.match.find.queue";
 
         private Queue() {}

--- a/infra/rabbitmq/src/main/java/com/mmrtr/lol/infra/rabbitmq/config/RabbitMqConfig.java
+++ b/infra/rabbitmq/src/main/java/com/mmrtr/lol/infra/rabbitmq/config/RabbitMqConfig.java
@@ -78,7 +78,10 @@ public class RabbitMqConfig {
 
     @Bean
     public Queue matchIdQueue() {
-        return new Queue(RabbitMqBinding.MATCH_ID.getQueue());
+        return QueueBuilder.durable(RabbitMqBinding.MATCH_ID.getQueue())
+                .withArgument("x-dead-letter-exchange", RabbitMqBinding.MATCH_ID_DLX.getExchange())
+                .withArgument("x-dead-letter-routing-key", RabbitMqBinding.MATCH_ID_DLX.getRoutingKey())
+                .build();
     }
 
     @Bean
@@ -92,6 +95,24 @@ public class RabbitMqConfig {
                 .bind(matchIdQueue())
                 .to(matchIdExchange())
                 .with(RabbitMqBinding.MATCH_ID.getRoutingKey());
+    }
+
+    @Bean
+    public Queue dlxMatchIdQueue() {
+        return new Queue(RabbitMqBinding.MATCH_ID_DLX.getQueue(), true);
+    }
+
+    @Bean
+    public DirectExchange matchIdDlxExchange() {
+        return new DirectExchange(RabbitMqBinding.MATCH_ID_DLX.getExchange());
+    }
+
+    @Bean
+    public Binding matchIdDlxBinding() {
+        return BindingBuilder
+                .bind(dlxMatchIdQueue())
+                .to(matchIdDlxExchange())
+                .with(RabbitMqBinding.MATCH_ID_DLX.getRoutingKey());
     }
 
     @Bean

--- a/infra/rabbitmq/src/main/java/com/mmrtr/lol/infra/rabbitmq/listener/MatchListener.java
+++ b/infra/rabbitmq/src/main/java/com/mmrtr/lol/infra/rabbitmq/listener/MatchListener.java
@@ -39,6 +39,7 @@ public class MatchListener {
 
         switch (result) {
             case DUPLICATE, SUCCESS -> safeAck(channel, deliveryTag);
+            case QUEUE_FULL -> safeNackRequeue(channel, deliveryTag);
             case FAILURE -> safeNack(channel, deliveryTag);
         }
     }
@@ -68,6 +69,21 @@ public class MatchListener {
             log.warn("Channel already closed during nack for deliveryTag {}: {}", deliveryTag, e.getMessage());
         } catch (IOException e) {
             log.warn("IOException during nack for deliveryTag {}: {}", deliveryTag, e.getMessage());
+        }
+    }
+
+    private void safeNackRequeue(Channel channel, long deliveryTag) {
+        try {
+            if (channel.isOpen()) {
+                channel.basicNack(deliveryTag, false, true);
+            } else {
+                log.warn("Channel is closed, cannot nack(requeue) deliveryTag {}.", deliveryTag);
+            }
+        } catch (AlreadyClosedException e) {
+            log.warn("Channel already closed during nack(requeue) for deliveryTag {}: {}",
+                    deliveryTag, e.getMessage());
+        } catch (IOException e) {
+            log.warn("IOException during nack(requeue) for deliveryTag {}: {}", deliveryTag, e.getMessage());
         }
     }
 }

--- a/infra/rabbitmq/src/main/java/com/mmrtr/lol/infra/rabbitmq/service/MatchBatchProcessor.java
+++ b/infra/rabbitmq/src/main/java/com/mmrtr/lol/infra/rabbitmq/service/MatchBatchProcessor.java
@@ -1,8 +1,10 @@
 package com.mmrtr.lol.infra.rabbitmq.service;
 
-import com.mmrtr.lol.domain.match.readmodel.MatchDto;
-import com.mmrtr.lol.domain.match.readmodel.timeline.TimelineDto;
+import com.mmrtr.lol.domain.match.application.port.MatchCacheEvictPort;
 import com.mmrtr.lol.domain.match.application.usecase.SaveMatchDataUseCase;
+import com.mmrtr.lol.domain.match.readmodel.MatchDto;
+import com.mmrtr.lol.domain.match.readmodel.ParticipantDto;
+import com.mmrtr.lol.domain.match.readmodel.timeline.TimelineDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.util.Pair;
@@ -10,7 +12,9 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
@@ -20,6 +24,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 public class MatchBatchProcessor {
 
     private final SaveMatchDataUseCase saveMatchDataUseCase;
+    private final MatchCacheEvictPort matchCacheEvictPort;
     private final BlockingQueue<Pair<MatchDto, TimelineDto>> queue = new LinkedBlockingQueue<>();
 
     public void add(Pair<MatchDto, TimelineDto> pair) {
@@ -41,6 +46,33 @@ public class MatchBatchProcessor {
             }
 
             saveMatchDataUseCase.execute(matchDtos, timelineDtos);
+
+            // 저장 성공 후 best-effort 캐시 무효화. 실패해도 저장 트랜잭션엔 영향 없음.
+            try {
+                matchCacheEvictPort.evictByPuuids(extractPuuids(matchDtos));
+            } catch (Exception e) {
+                log.warn("cache evict 중 예외 발생, 저장은 정상 완료: {}", e.getMessage());
+            }
         }
+    }
+
+    private Set<String> extractPuuids(List<MatchDto> matchDtos) {
+        Set<String> puuids = new HashSet<>();
+        for (MatchDto matchDto : matchDtos) {
+            if (matchDto == null || matchDto.getInfo() == null) {
+                continue;
+            }
+            List<ParticipantDto> participants = matchDto.getInfo().getParticipants();
+            if (participants == null) {
+                continue;
+            }
+            for (ParticipantDto participant : participants) {
+                String puuid = participant.getPuuid();
+                if (puuid != null && !puuid.isBlank()) {
+                    puuids.add(puuid);
+                }
+            }
+        }
+        return puuids;
     }
 }

--- a/infra/rabbitmq/src/main/java/com/mmrtr/lol/infra/rabbitmq/service/MatchBatchProcessor.java
+++ b/infra/rabbitmq/src/main/java/com/mmrtr/lol/infra/rabbitmq/service/MatchBatchProcessor.java
@@ -23,18 +23,25 @@ import java.util.concurrent.LinkedBlockingQueue;
 @RequiredArgsConstructor
 public class MatchBatchProcessor {
 
+    // prefetch=1 × concurrent=20 = 최대 20 in-flight. flush 지연 대비 25배 안전치(500).
+    private static final int QUEUE_CAPACITY = 500;
+    private static final int DRAIN_LIMIT = 1000;
+
     private final SaveMatchDataUseCase saveMatchDataUseCase;
     private final MatchCacheEvictPort matchCacheEvictPort;
-    private final BlockingQueue<Pair<MatchDto, TimelineDto>> queue = new LinkedBlockingQueue<>();
+    private final BlockingQueue<Pair<MatchDto, TimelineDto>> queue = new LinkedBlockingQueue<>(QUEUE_CAPACITY);
 
-    public void add(Pair<MatchDto, TimelineDto> pair) {
-        queue.add(pair);
+    /**
+     * 비차단 enqueue. 큐가 가득 차면 false 를 반환해 호출자가 RabbitMQ requeue 로 backpressure 를 걸도록 한다.
+     */
+    public boolean add(Pair<MatchDto, TimelineDto> pair) {
+        return queue.offer(pair);
     }
 
     @Scheduled(fixedRate = 1000)
     public void flush() {
         List<Pair<MatchDto, TimelineDto>> pairs = new ArrayList<>();
-        int count = queue.drainTo(pairs);
+        int count = queue.drainTo(pairs, DRAIN_LIMIT);
         if (count > 0) {
             log.debug("배치 저장 데이터 갯수: {}", count);
 

--- a/infra/rabbitmq/src/main/java/com/mmrtr/lol/infra/rabbitmq/service/MatchDataProcessor.java
+++ b/infra/rabbitmq/src/main/java/com/mmrtr/lol/infra/rabbitmq/service/MatchDataProcessor.java
@@ -32,7 +32,8 @@ public class MatchDataProcessor {
     public enum Result {
         DUPLICATE,
         SUCCESS,
-        FAILURE
+        FAILURE,
+        QUEUE_FULL
     }
 
     public Result process(String matchId, String platformName) {
@@ -65,7 +66,10 @@ public class MatchDataProcessor {
             return Result.FAILURE;
         }
 
-        matchBatchProcessor.add(dtoPair);
+        if (!matchBatchProcessor.add(dtoPair)) {
+            log.warn("Match batch queue is full, requeueing matchId {}", matchId);
+            return Result.QUEUE_FULL;
+        }
         return Result.SUCCESS;
     }
 }

--- a/infra/rabbitmq/src/test/java/com/mmrtr/lol/infra/rabbitmq/service/MatchBatchProcessorTest.java
+++ b/infra/rabbitmq/src/test/java/com/mmrtr/lol/infra/rabbitmq/service/MatchBatchProcessorTest.java
@@ -1,0 +1,77 @@
+package com.mmrtr.lol.infra.rabbitmq.service;
+
+import com.mmrtr.lol.domain.match.application.port.MatchCacheEvictPort;
+import com.mmrtr.lol.domain.match.application.usecase.SaveMatchDataUseCase;
+import com.mmrtr.lol.domain.match.readmodel.InfoDto;
+import com.mmrtr.lol.domain.match.readmodel.MatchDto;
+import com.mmrtr.lol.domain.match.readmodel.ParticipantDto;
+import com.mmrtr.lol.domain.match.readmodel.timeline.TimelineDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.util.Pair;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class MatchBatchProcessorTest {
+
+    private SaveMatchDataUseCase saveMatchDataUseCase;
+    private MatchCacheEvictPort matchCacheEvictPort;
+    private MatchBatchProcessor processor;
+
+    @BeforeEach
+    void setUp() {
+        saveMatchDataUseCase = mock(SaveMatchDataUseCase.class);
+        matchCacheEvictPort = mock(MatchCacheEvictPort.class);
+        processor = new MatchBatchProcessor(saveMatchDataUseCase, matchCacheEvictPort);
+    }
+
+    @Test
+    @DisplayName("flush 후 모든 참가자 puuid 가 캐시 evict port 로 전달된다")
+    void flush_evictsAllParticipantPuuids() {
+        MatchDto m1 = matchWithPuuids(List.of("puuid-a", "puuid-b"));
+        MatchDto m2 = matchWithPuuids(List.of("puuid-b", "puuid-c"));
+        processor.add(Pair.of(m1, new TimelineDto()));
+        processor.add(Pair.of(m2, new TimelineDto()));
+
+        processor.flush();
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Set<String>> captor = ArgumentCaptor.forClass(Set.class);
+        verify(matchCacheEvictPort, times(1)).evictByPuuids(captor.capture());
+        assertThat(captor.getValue()).containsExactlyInAnyOrder("puuid-a", "puuid-b", "puuid-c");
+    }
+
+    @Test
+    @DisplayName("큐가 비어있으면 save 와 evict 모두 호출되지 않는다")
+    void flush_emptyQueue_doesNothing() {
+        processor.flush();
+
+        verify(saveMatchDataUseCase, never()).execute(any(), any());
+        verify(matchCacheEvictPort, never()).evictByPuuids(any());
+    }
+
+    private MatchDto matchWithPuuids(List<String> puuids) {
+        MatchDto dto = new MatchDto();
+        InfoDto info = new InfoDto();
+        List<ParticipantDto> participants = new ArrayList<>();
+        for (String puuid : puuids) {
+            ParticipantDto p = new ParticipantDto();
+            p.setPuuid(puuid);
+            participants.add(p);
+        }
+        info.setParticipants(participants);
+        dto.setInfo(info);
+        return dto;
+    }
+}

--- a/infra/rabbitmq/src/test/java/com/mmrtr/lol/infra/rabbitmq/service/MatchBatchProcessorTest.java
+++ b/infra/rabbitmq/src/test/java/com/mmrtr/lol/infra/rabbitmq/service/MatchBatchProcessorTest.java
@@ -61,6 +61,19 @@ class MatchBatchProcessorTest {
         verify(matchCacheEvictPort, never()).evictByPuuids(any());
     }
 
+    @Test
+    @DisplayName("큐가 가득 차면 add 는 false 를 반환한다 (backpressure)")
+    void add_returnsFalse_whenQueueIsFull() {
+        // 큐 용량 500 — 채워 넣은 뒤 추가 add 가 거절되는지 확인
+        for (int i = 0; i < 500; i++) {
+            boolean accepted = processor.add(Pair.of(new MatchDto(), new TimelineDto()));
+            assertThat(accepted).isTrue();
+        }
+
+        boolean overflow = processor.add(Pair.of(new MatchDto(), new TimelineDto()));
+        assertThat(overflow).isFalse();
+    }
+
     private MatchDto matchWithPuuids(List<String> puuids) {
         MatchDto dto = new MatchDto();
         InfoDto info = new InfoDto();

--- a/infra/redis/build.gradle
+++ b/infra/redis/build.gradle
@@ -6,4 +6,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.redisson:redisson-spring-boot-starter:3.46.0'
 
+    // Metrics
+    implementation 'io.micrometer:micrometer-core'
 }

--- a/infra/redis/src/main/java/com/mmrtr/lol/infra/redis/adapter/MatchCacheEvictAdapter.java
+++ b/infra/redis/src/main/java/com/mmrtr/lol/infra/redis/adapter/MatchCacheEvictAdapter.java
@@ -1,0 +1,52 @@
+package com.mmrtr.lol.infra.redis.adapter;
+
+import com.mmrtr.lol.domain.match.application.port.MatchCacheEvictPort;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RKeys;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+
+/**
+ * lol-server 매치 리스트 캐시(`match:list:v1:{puuid}:{season}:{queueId}:{pageNo}`)를
+ * Redisson SCAN+DEL 패턴으로 제거하는 adapter.
+ *
+ * <p>실패해도 호출자(저장 파이프라인) 에 예외를 전파하지 않는 best-effort 동작.
+ */
+@Slf4j
+@Component
+public class MatchCacheEvictAdapter implements MatchCacheEvictPort {
+
+    private static final String MATCH_LIST_PATTERN_PREFIX = "match:list:v1:";
+
+    private final RedissonClient redissonClient;
+    private final MeterRegistry meterRegistry;
+
+    public MatchCacheEvictAdapter(RedissonClient redissonClient, MeterRegistry meterRegistry) {
+        this.redissonClient = redissonClient;
+        this.meterRegistry = meterRegistry;
+    }
+
+    @Override
+    public void evictByPuuids(Set<String> puuids) {
+        if (puuids == null || puuids.isEmpty()) {
+            return;
+        }
+
+        long deleted = 0L;
+        try {
+            RKeys keys = redissonClient.getKeys();
+            for (String puuid : puuids) {
+                String pattern = MATCH_LIST_PATTERN_PREFIX + puuid + ":*";
+                deleted += keys.deleteByPattern(pattern);
+            }
+            log.info("cache.match.evict puuid_count={} keys_deleted={}", puuids.size(), deleted);
+            meterRegistry.counter("cache.match.evict", "result", "success").increment();
+        } catch (Exception e) {
+            log.warn("cache.match.evict failed puuid_count={} cause={}", puuids.size(), e.getMessage());
+            meterRegistry.counter("cache.match.evict", "result", "failure").increment();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

세 가지를 한 번에 묶은 batch 파이프라인 개선:

1. **lol-server 매치 캐시 무효화** — 매치 적재 직후 영향 puuid 들의 cache key 를 SCAN+DEL
2. **MatchBatchProcessor 큐 안정성** — unbounded LinkedBlockingQueue 로 인한 OOM 위험 제거 + 백프레셔
3. **MATCH_ID 큐 DLX 신규 바인딩** — 이전엔 FAILURE 메시지가 사일런트 drop 되던 문제 해결

## Changes

### (A) Cache invalidation — `88fb0a0`

- **신규**: `MatchCacheEvictPort` (core/domain) + `MatchCacheEvictAdapter` (infra/redis)
- `MatchBatchProcessor.flush()` 후 `SaveMatchDataUseCase.execute()` 성공 시에만 호출
- 적재된 매치들의 `info.participants.puuid` 추출 → `redissonClient.getKeys().deleteByPattern("match:list:v1:" + puuid + ":*")`
- **best-effort**: try/catch swallow + Micrometer counter `cache.match.evict{result=success|failure}`. 캐시 무효화 실패가 DB 저장을 롤백시키지 않음.
- null-safe 가드 (matchDto / info / participants / blank puuid)

### (B) Queue stability — `18768ac`

- `LinkedBlockingQueue` cap **500** (prefetch=1 × concurrent=20 = 20 in-flight × 25× safety)
- `MatchBatchProcessor.add()`: `queue.add()` → `queue.offer()` (non-blocking, returns boolean)
- `MatchDataProcessor.Result.QUEUE_FULL` enum 신규
- `MatchListener.receiveMessage()` switch 확장:
  - `SUCCESS | DUPLICATE` → `safeAck`
  - `QUEUE_FULL` → `safeNackRequeue` (requeue=**true**, 자연스러운 백프레셔)
  - `FAILURE` → `safeNack` (requeue=false, DLX 로)
- `queue.drainTo(pairs, 1000)` flush 사이즈 cap (CLAUDE.md 의 "배치 크기 1000" 명세 일치)

### (C) MATCH_ID DLX — `18768ac`

- `RabbitMqBinding.MATCH_ID_DLX` enum 항목 신규
- `matchIdQueue` 가 QueueBuilder 로 변경 (`x-dead-letter-exchange` / `x-dead-letter-routing-key` argument 추가)
- 신규 빈: `dlxMatchIdQueue` / `matchIdDlxExchange` / `matchIdDlxBinding`
- DLX queue: `mmrtr.matchId.dlx`, routing key `deadLetter` (SUMMONER_DLX 패턴 미러링)

## Test plan

- [x] `./gradlew check` BUILD SUCCESSFUL
- [x] `MatchBatchProcessorTest` 신규 3개 통과: puuid 추출 / 빈 큐 noop / queue-full 백프레셔
- [x] DLX argument map 검증 (x-dead-letter-exchange + routing key)
- [ ] 로컬에서 SCAN+DEL 동작 실측 (lol-server 캐시와 통합)
- [ ] DLX 라우팅 통합 테스트 (FAILURE 메시지가 mmrtr.matchId.dlx 로 들어가는지)

## 새 컴포넌트 의존 추가

- `infra/redis/build.gradle` 에 `io.micrometer:micrometer-core` 추가 (evict counter 용)

## Related

- lol-server cache port/adapter PR: padosol/lol-server#109
- 두 PR 독립 deploy 가능. 권장 순서: lol-server 먼저 → 이 PR