### PR TITLE
refactor(match): Redis batch write + async DB save + API timing logs

### DIFF
--- a/core/domain/src/main/java/com/mmrtr/lol/domain/match/application/port/MatchCacheWritePort.java
+++ b/core/domain/src/main/java/com/mmrtr/lol/domain/match/application/port/MatchCacheWritePort.java
@@ -2,21 +2,23 @@ package com.mmrtr.lol.domain.match.application.port;
 
 import com.mmrtr.lol.domain.match.readmodel.MatchDto;
 
+import java.util.List;
+
 /**
  * lol-server 가 즉시 조회 가능하도록 매치 데이터를 Redis 에 write-through 하기 위한 outbound port.
  * <p>
- * lol-repository 가 Riot API 로부터 매치를 파싱한 직후 호출되며, 단건 매치 캐시와
- * 참가자 별 매치 ID 정렬 셋(ZSET) 을 한 번의 pipeline 으로 기록한다. 실패해도
- * 저장 파이프라인에는 영향을 주지 않는 best-effort 동작이다.
+ * 갱신을 요청한 본인 puuid 의 ZSET 에만 매치 ID 를 추가한다. 다른 참가자의 ZSET 은 건드리지 않아
+ * "최근 갱신 유저만 캐시 hit" 정책을 유지한다. 단건 매치 캐시는 모든 유저가 공유하므로 그대로 SET 한다.
+ * 실패해도 저장 파이프라인에는 영향을 주지 않는 best-effort 동작이다.
  */
 public interface MatchCacheWritePort {
 
     /**
-     * 단건 매치(`match:v1:{matchId}`) 와 참가자 별 매치 ID ZSET(`match:ids:v1:{puuid}`) 을
-     * Redis 에 기록한다. 호출은 best-effort 이며 예외를 호출자에게 전파하지 않는다.
+     * 단건 매치(`match:v1:{matchId}`) N 개와 요청자 puuid 의 매치 ID ZSET(`match:ids:v1:{requesterPuuid}`) 을
+     * 한 번의 Redis pipeline 으로 기록한다. 호출은 best-effort 이며 예외를 호출자에게 전파하지 않는다.
      *
-     * @param match Riot API 에서 받아 파싱한 매치 DTO (metadata.matchId, info.gameCreation,
-     *              info.participants[].puuid 필요)
+     * @param matches         Riot API 에서 받아 파싱한 매치 DTO 목록 (각 metadata.matchId, info.gameCreation 필요)
+     * @param requesterPuuid  갱신을 요청한 유저의 puuid. 이 puuid 의 ZSET 에만 매치 ID 가 추가된다.
      */
-    void writeMatch(MatchDto match);
+    void writeMatches(List<MatchDto> matches, String requesterPuuid);
 }

--- a/infra/rabbitmq/src/main/java/com/mmrtr/lol/infra/rabbitmq/service/AsyncMatchSaver.java
+++ b/infra/rabbitmq/src/main/java/com/mmrtr/lol/infra/rabbitmq/service/AsyncMatchSaver.java
@@ -1,0 +1,35 @@
+package com.mmrtr.lol.infra.rabbitmq.service;
+
+import com.mmrtr.lol.domain.match.application.usecase.SaveMatchDataUseCase;
+import com.mmrtr.lol.domain.match.readmodel.MatchDto;
+import com.mmrtr.lol.domain.match.readmodel.timeline.TimelineDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AsyncMatchSaver {
+
+    private final SaveMatchDataUseCase saveMatchDataUseCase;
+    private final Executor matchSaveExecutor;
+
+    public void saveAsync(List<MatchDto> matches, List<TimelineDto> timelines) {
+        if (matches == null || matches.isEmpty()) {
+            return;
+        }
+        CompletableFuture.runAsync(() -> {
+            try {
+                saveMatchDataUseCase.execute(matches, timelines);
+            } catch (Exception e) {
+                log.error("매치 비동기 DB 적재 실패. count={} cause={}",
+                        matches.size(), e.getMessage(), e);
+            }
+        }, matchSaveExecutor);
+    }
+}

--- a/infra/rabbitmq/src/main/java/com/mmrtr/lol/infra/rabbitmq/service/MatchDataProcessor.java
+++ b/infra/rabbitmq/src/main/java/com/mmrtr/lol/infra/rabbitmq/service/MatchDataProcessor.java
@@ -3,7 +3,6 @@ package com.mmrtr.lol.infra.rabbitmq.service;
 import com.mmrtr.lol.domain.match.readmodel.MatchDto;
 import com.mmrtr.lol.domain.match.readmodel.timeline.TimelineDto;
 import com.mmrtr.lol.domain.match.application.port.MatchApiPort;
-import com.mmrtr.lol.domain.match.application.port.MatchCacheWritePort;
 import com.mmrtr.lol.infra.redis.service.MatchRedisService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,7 +26,6 @@ public class MatchDataProcessor {
     private final MatchApiPort matchApiPort;
     private final MatchRedisService matchRedisService;
     private final MatchBatchProcessor matchBatchProcessor;
-    private final MatchCacheWritePort matchCacheWritePort;
     private final Executor riotApiExecutor;
     private final RRateLimiter globalApiRateLimiter;
 
@@ -67,11 +65,6 @@ public class MatchDataProcessor {
             log.warn("Failed to fetch data for matchId {}: {}", matchId, e.getCause().getMessage());
             return Result.FAILURE;
         }
-
-        // 매치 데이터를 Redis 에 write-through (best-effort). DB insert 전에 호출하여
-        // lol-server 가 최신 매치를 즉시 조회할 수 있게 한다. 어댑터 내부에서 예외를 swallow 하므로
-        // 처리 흐름엔 영향이 없다.
-        matchCacheWritePort.writeMatch(dtoPair.getFirst());
 
         if (!matchBatchProcessor.add(dtoPair)) {
             log.warn("Match batch queue is full, requeueing matchId {}", matchId);

--- a/infra/rabbitmq/src/main/java/com/mmrtr/lol/infra/rabbitmq/service/SummonerRenewalService.java
+++ b/infra/rabbitmq/src/main/java/com/mmrtr/lol/infra/rabbitmq/service/SummonerRenewalService.java
@@ -1,9 +1,9 @@
 package com.mmrtr.lol.infra.rabbitmq.service;
 
 import com.mmrtr.lol.common.type.Platform;
+import com.mmrtr.lol.domain.match.application.port.MatchCacheWritePort;
 import com.mmrtr.lol.domain.match.readmodel.MatchDto;
 import com.mmrtr.lol.domain.match.readmodel.timeline.TimelineDto;
-import com.mmrtr.lol.domain.match.application.usecase.SaveMatchDataUseCase;
 import com.mmrtr.lol.domain.summoner.domain.Summoner;
 import com.mmrtr.lol.domain.summoner.application.port.SummonerRepositoryPort;
 import com.mmrtr.lol.domain.summoner.application.usecase.SaveSummonerDataUseCase;
@@ -32,14 +32,25 @@ public class SummonerRenewalService {
     private final SummonerRepositoryPort summonerRepositoryPort;
     private final MatchDataFetcher matchDataFetcher;
     private final SaveSummonerDataUseCase saveSummonerDataUseCase;
-    private final SaveMatchDataUseCase saveMatchDataUseCase;
+    private final MatchCacheWritePort matchCacheWritePort;
+    private final AsyncMatchSaver asyncMatchSaver;
     private final RabbitTemplate rabbitTemplate;
     private final Executor requestExecutor;
 
     public void renewSummoner(String puuid, Platform platform) {
         log.info("[갱신 시작] puuid={}", puuid);
+        long renewalStart = System.currentTimeMillis();
+        try {
+            doRenew(puuid, platform);
+        } finally {
+            log.info("[갱신 완료] puuid={} 총 소요: {}ms", puuid, System.currentTimeMillis() - renewalStart);
+        }
+    }
 
+    private void doRenew(String puuid, Platform platform) {
+        long t = System.currentTimeMillis();
         SummonerDto summonerDto = summonerDataCollector.fetchSummoner(puuid, platform, requestExecutor);
+        log.debug("[갱신-API] fetchSummoner: {}ms puuid={}", System.currentTimeMillis() - t, puuid);
         if (summonerDto == null) {
             log.error("RIOT API에서 소환사 정보를 조회할 수 없습니다. puuid: {}", puuid);
             return;
@@ -51,16 +62,22 @@ public class SummonerRenewalService {
             return;
         }
 
+        t = System.currentTimeMillis();
         Optional<Summoner> summonerOpt = summonerDataCollector
                 .collectAndAssemble(puuid, platform, summonerDto, requestExecutor);
+        log.debug("[갱신-API] collectAndAssemble: {}ms puuid={}", System.currentTimeMillis() - t, puuid);
         if (summonerOpt.isEmpty()) {
             return;
         }
 
         Summoner summoner = summonerOpt.get();
+        t = System.currentTimeMillis();
         FetchNewMatchIdsResult fetchResult = matchDataFetcher
                 .fetchNewMatchIds(puuid, platform, revisionCheck.dbRevisionDateSeconds(), requestExecutor).join();
+        log.debug("[갱신-API] fetchNewMatchIds: {}ms count={} puuid={}",
+                System.currentTimeMillis() - t, fetchResult.newMatchIds().size(), puuid);
 
+        t = System.currentTimeMillis();
         CompletableFuture<List<MatchDto>> matchDetailsFuture = matchDataFetcher
                 .fetchMatchDetails(fetchResult.newMatchIds(), platform, requestExecutor);
         CompletableFuture<List<TimelineDto>> timelinesFuture = matchDataFetcher
@@ -68,15 +85,16 @@ public class SummonerRenewalService {
 
         List<MatchDto> matchDtos = matchDetailsFuture.join();
         List<TimelineDto> timelineDtos = timelinesFuture.join();
+        log.debug("[갱신-API] fetchMatchDetails+Timelines (parallel): {}ms count={} puuid={}",
+                System.currentTimeMillis() - t, matchDtos.size(), puuid);
 
         summoner.updateLastRiotCallDate();
         summonerDataCollector.save(summoner);
 
         if (matchDtos != null && !matchDtos.isEmpty()) {
-            saveMatchDataUseCase.execute(matchDtos, timelineDtos);
+            matchCacheWritePort.writeMatches(matchDtos, puuid);
+            asyncMatchSaver.saveAsync(matchDtos, timelineDtos);
         }
-
-        log.info("[갱신 완료] puuid={}", puuid);
 
         if (fetchResult.hasMoreMatches()) {
             log.info("갱신 완료 후 추가 매치 검색 MQ 발행. puuid={}", puuid);

--- a/infra/rabbitmq/src/test/java/com/mmrtr/lol/infra/rabbitmq/service/AsyncMatchSaverTest.java
+++ b/infra/rabbitmq/src/test/java/com/mmrtr/lol/infra/rabbitmq/service/AsyncMatchSaverTest.java
@@ -1,0 +1,73 @@
+package com.mmrtr.lol.infra.rabbitmq.service;
+
+import com.mmrtr.lol.domain.match.application.usecase.SaveMatchDataUseCase;
+import com.mmrtr.lol.domain.match.readmodel.MatchDto;
+import com.mmrtr.lol.domain.match.readmodel.timeline.TimelineDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Executor;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+class AsyncMatchSaverTest {
+
+    private SaveMatchDataUseCase saveMatchDataUseCase;
+    private AsyncMatchSaver asyncMatchSaver;
+
+    @BeforeEach
+    void setUp() {
+        saveMatchDataUseCase = mock(SaveMatchDataUseCase.class);
+        Executor sameThreadExecutor = Runnable::run;
+        asyncMatchSaver = new AsyncMatchSaver(saveMatchDataUseCase, sameThreadExecutor);
+    }
+
+    @Test
+    @DisplayName("matches 가 null 이면 SaveMatchDataUseCase 호출 안 함")
+    void saveAsync_skipsWhenMatchesNull() {
+        asyncMatchSaver.saveAsync(null, List.of());
+
+        verifyNoInteractions(saveMatchDataUseCase);
+    }
+
+    @Test
+    @DisplayName("matches 가 빈 리스트면 SaveMatchDataUseCase 호출 안 함")
+    void saveAsync_skipsWhenMatchesEmpty() {
+        asyncMatchSaver.saveAsync(Collections.emptyList(), List.of());
+
+        verifyNoInteractions(saveMatchDataUseCase);
+    }
+
+    @Test
+    @DisplayName("정상 흐름: SaveMatchDataUseCase.execute 에 동일 인자로 위임한다")
+    void saveAsync_delegatesToUseCase() {
+        MatchDto match = new MatchDto();
+        TimelineDto timeline = new TimelineDto();
+        List<MatchDto> matches = List.of(match);
+        List<TimelineDto> timelines = List.of(timeline);
+
+        asyncMatchSaver.saveAsync(matches, timelines);
+
+        verify(saveMatchDataUseCase, times(1)).execute(matches, timelines);
+    }
+
+    @Test
+    @DisplayName("SaveMatchDataUseCase 가 예외 던져도 호출자에게 전파하지 않는다 (swallow)")
+    void saveAsync_swallowsException() {
+        MatchDto match = new MatchDto();
+        List<MatchDto> matches = List.of(match);
+        List<TimelineDto> timelines = List.of();
+        doThrow(new RuntimeException("DB down")).when(saveMatchDataUseCase).execute(matches, timelines);
+
+        asyncMatchSaver.saveAsync(matches, timelines);
+
+        verify(saveMatchDataUseCase, times(1)).execute(matches, timelines);
+    }
+}

--- a/infra/redis/src/main/java/com/mmrtr/lol/infra/redis/adapter/MatchCacheWriteAdapter.java
+++ b/infra/redis/src/main/java/com/mmrtr/lol/infra/redis/adapter/MatchCacheWriteAdapter.java
@@ -5,7 +5,6 @@ import com.mmrtr.lol.domain.match.application.port.MatchCacheWritePort;
 import com.mmrtr.lol.domain.match.readmodel.InfoDto;
 import com.mmrtr.lol.domain.match.readmodel.MatchDto;
 import com.mmrtr.lol.domain.match.readmodel.MetadataDto;
-import com.mmrtr.lol.domain.match.readmodel.ParticipantDto;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RBatch;
@@ -14,7 +13,9 @@ import org.redisson.client.codec.StringCodec;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -22,13 +23,12 @@ import java.util.concurrent.TimeUnit;
  *
  * <p>저장 키:
  * <ul>
- *   <li>{@code match:v1:{matchId}} - 단건 매치 JSON, 1시간 TTL</li>
- *   <li>{@code match:ids:v1:{puuid}} - 참가자 별 최근 매치 ID ZSET (score = gameCreation),
- *       크기 20 으로 trim, 24시간 TTL</li>
+ *   <li>{@code match:v1:{matchId}} - 단건 매치 JSON, 3분 TTL (모든 유저 공유)</li>
+ *   <li>{@code match:ids:v1:{requesterPuuid}} - 갱신 요청자 ZSET (score = gameCreation),
+ *       크기 20 으로 trim, 3분 TTL. 다른 참가자의 ZSET 은 채우지 않아 "최근 갱신 유저만 캐시" 유지</li>
  * </ul>
  *
- * <p>모든 작업은 {@link RBatch} pipeline 으로 1 RTT 에 수행되며, 실패 시 swallow + 메트릭 기록
- * (호출자 = 저장 파이프라인에 예외 전파하지 않음).
+ * <p>매치 N 개를 한 번의 {@link RBatch} pipeline 으로 1 RTT 에 처리한다. 실패 시 swallow + 메트릭 기록.
  */
 @Slf4j
 @Component
@@ -36,8 +36,8 @@ public class MatchCacheWriteAdapter implements MatchCacheWritePort {
 
     private static final String MATCH_KEY_PREFIX = "match:v1:";
     private static final String MATCH_IDS_KEY_PREFIX = "match:ids:v1:";
-    private static final Duration MATCH_TTL = Duration.ofHours(1);
-    private static final Duration MATCH_IDS_TTL = Duration.ofHours(24);
+    private static final Duration MATCH_TTL = Duration.ofMinutes(3);
+    private static final Duration MATCH_IDS_TTL = Duration.ofMinutes(3);
     private static final int MATCH_IDS_TRIM_KEEP = 20;
 
     private final RedissonClient redissonClient;
@@ -55,52 +55,62 @@ public class MatchCacheWriteAdapter implements MatchCacheWritePort {
     }
 
     @Override
-    public void writeMatch(MatchDto match) {
-        if (match == null) {
+    public void writeMatches(List<MatchDto> matches, String requesterPuuid) {
+        if (matches == null || matches.isEmpty()) {
             return;
+        }
+        if (requesterPuuid == null || requesterPuuid.isBlank()) {
+            log.warn("cache.match.write skipped: blank requesterPuuid matchCount={}", matches.size());
+            meterRegistry.counter("cache.match.write", "result", "skipped").increment();
+            return;
+        }
+
+        try {
+            RBatch batch = redissonClient.createBatch();
+            Map<String, Double> zsetMembers = new HashMap<>();
+
+            for (MatchDto match : matches) {
+                String matchId = extractMatchId(match);
+                if (matchId == null) {
+                    continue;
+                }
+                String json = objectMapper.writeValueAsString(match);
+                batch.getBucket(MATCH_KEY_PREFIX + matchId, StringCodec.INSTANCE)
+                        .setAsync(json, MATCH_TTL);
+                zsetMembers.put(matchId, (double) match.getInfo().getGameCreation());
+            }
+
+            if (zsetMembers.isEmpty()) {
+                return;
+            }
+
+            String zsetKey = MATCH_IDS_KEY_PREFIX + requesterPuuid;
+            batch.<String>getScoredSortedSet(zsetKey, StringCodec.INSTANCE).addAllAsync(zsetMembers);
+            batch.<String>getScoredSortedSet(zsetKey, StringCodec.INSTANCE)
+                    .removeRangeByRankAsync(0, -(MATCH_IDS_TRIM_KEEP + 1));
+            batch.getKeys().expireAsync(zsetKey, MATCH_IDS_TTL.toSeconds(), TimeUnit.SECONDS);
+
+            batch.execute();
+            meterRegistry.counter("cache.match.write", "result", "success").increment(zsetMembers.size());
+        } catch (Exception e) {
+            log.warn("cache.match.write failed count={} cause={}", matches.size(), e.getMessage());
+            meterRegistry.counter("cache.match.write", "result", "failure").increment(matches.size());
+        }
+    }
+
+    private String extractMatchId(MatchDto match) {
+        if (match == null) {
+            return null;
         }
         MetadataDto metadata = match.getMetadata();
         InfoDto info = match.getInfo();
         if (metadata == null || info == null) {
-            return;
+            return null;
         }
         String matchId = metadata.getMatchId();
         if (matchId == null || matchId.isBlank()) {
-            return;
+            return null;
         }
-        long gameCreation = info.getGameCreation();
-        List<ParticipantDto> participants = info.getParticipants();
-
-        try {
-            String json = objectMapper.writeValueAsString(match);
-
-            RBatch batch = redissonClient.createBatch();
-            batch.getBucket(MATCH_KEY_PREFIX + matchId, StringCodec.INSTANCE)
-                    .setAsync(json, MATCH_TTL);
-
-            if (participants != null) {
-                for (ParticipantDto participant : participants) {
-                    if (participant == null) {
-                        continue;
-                    }
-                    String puuid = participant.getPuuid();
-                    if (puuid == null || puuid.isBlank()) {
-                        continue;
-                    }
-                    String zsetKey = MATCH_IDS_KEY_PREFIX + puuid;
-                    batch.getScoredSortedSet(zsetKey, StringCodec.INSTANCE)
-                            .addAsync((double) gameCreation, matchId);
-                    batch.getScoredSortedSet(zsetKey, StringCodec.INSTANCE)
-                            .removeRangeByRankAsync(0, -(MATCH_IDS_TRIM_KEEP + 1));
-                    batch.getKeys().expireAsync(zsetKey, MATCH_IDS_TTL.toSeconds(), TimeUnit.SECONDS);
-                }
-            }
-
-            batch.execute();
-            meterRegistry.counter("cache.match.write", "result", "success").increment();
-        } catch (Exception e) {
-            log.warn("cache.match.write failed matchId={} cause={}", matchId, e.getMessage());
-            meterRegistry.counter("cache.match.write", "result", "failure").increment();
-        }
+        return matchId;
     }
 }

--- a/infra/redis/src/test/java/com/mmrtr/lol/infra/redis/adapter/MatchCacheWriteAdapterTest.java
+++ b/infra/redis/src/test/java/com/mmrtr/lol/infra/redis/adapter/MatchCacheWriteAdapterTest.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mmrtr.lol.domain.match.readmodel.InfoDto;
 import com.mmrtr.lol.domain.match.readmodel.MatchDto;
 import com.mmrtr.lol.domain.match.readmodel.MetadataDto;
-import com.mmrtr.lol.domain.match.readmodel.ParticipantDto;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,17 +18,17 @@ import org.redisson.api.RedissonClient;
 import org.redisson.client.codec.Codec;
 
 import java.time.Duration;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -39,7 +38,7 @@ class MatchCacheWriteAdapterTest {
 
     private RedissonClient redissonClient;
     private RBatch batch;
-    private RBucketAsync<String> bucket;
+    private Map<String, RBucketAsync<String>> bucketByKey;
     private RKeysAsync keys;
     private Map<String, RScoredSortedSetAsync<String>> zsetByKey;
     private MeterRegistry meterRegistry;
@@ -51,12 +50,15 @@ class MatchCacheWriteAdapterTest {
     void setUp() {
         redissonClient = mock(RedissonClient.class);
         batch = mock(RBatch.class);
-        bucket = mock(RBucketAsync.class);
+        bucketByKey = new HashMap<>();
         keys = mock(RKeysAsync.class);
         zsetByKey = new HashMap<>();
 
         when(redissonClient.createBatch()).thenReturn(batch);
-        when(batch.<String>getBucket(anyString(), any(Codec.class))).thenReturn(bucket);
+        when(batch.<String>getBucket(anyString(), any(Codec.class))).thenAnswer(inv -> {
+            String key = inv.getArgument(0);
+            return bucketByKey.computeIfAbsent(key, k -> mock(RBucketAsync.class));
+        });
         when(batch.getKeys()).thenReturn(keys);
         when(batch.<String>getScoredSortedSet(anyString(), any(Codec.class))).thenAnswer(inv -> {
             String key = inv.getArgument(0);
@@ -69,94 +71,109 @@ class MatchCacheWriteAdapterTest {
     }
 
     @Test
-    @DisplayName("매치 SET + 참가자 10명 ZADD/TRIM/EXPIRE 가 모두 한 batch 로 실행된다")
-    void writeMatch_writesBucketAndAllParticipantZSets() {
-        MatchDto match = buildMatch("KR_42", 1700000000000L, List.of(
-                "p0", "p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8", "p9"
-        ));
+    @DisplayName("N 매치 SET + 요청자 ZSET 1개 ZADD/TRIM/EXPIRE 가 단일 batch 로 실행된다")
+    void writeMatches_singleBatchForAllMatches() {
+        MatchDto m1 = buildMatch("KR_1", 100L);
+        MatchDto m2 = buildMatch("KR_2", 200L);
+        MatchDto m3 = buildMatch("KR_3", 300L);
 
-        adapter.writeMatch(match);
+        adapter.writeMatches(List.of(m1, m2, m3), "p3");
 
-        verify(batch).execute();
+        verify(batch, times(1)).execute();
 
-        // 단건 SET 확인
-        verify(batch).getBucket(eq("match:v1:KR_42"), any(Codec.class));
-        ArgumentCaptor<String> jsonCaptor = ArgumentCaptor.forClass(String.class);
-        verify(bucket).setAsync(jsonCaptor.capture(), eq(Duration.ofHours(1)));
-        assertThat(jsonCaptor.getValue()).contains("\"matchId\":\"KR_42\"");
+        assertThat(bucketByKey).containsOnlyKeys("match:v1:KR_1", "match:v1:KR_2", "match:v1:KR_3");
+        verify(bucketByKey.get("match:v1:KR_1")).setAsync(jsonContaining("KR_1"), eq(Duration.ofMinutes(3)));
+        verify(bucketByKey.get("match:v1:KR_2")).setAsync(jsonContaining("KR_2"), eq(Duration.ofMinutes(3)));
+        verify(bucketByKey.get("match:v1:KR_3")).setAsync(jsonContaining("KR_3"), eq(Duration.ofMinutes(3)));
 
-        // 참가자 10명 각각에 대해 ZADD / TRIM / EXPIRE
-        for (int i = 0; i < 10; i++) {
-            String zsetKey = "match:ids:v1:p" + i;
-            RScoredSortedSetAsync<String> zset = zsetByKey.get(zsetKey);
-            assertThat(zset).as("zset for puuid p%d", i).isNotNull();
-            verify(zset).addAsync(1700000000000.0, "KR_42");
-            verify(zset).removeRangeByRankAsync(0, -21);
-            verify(keys).expireAsync(eq(zsetKey), eq(Duration.ofHours(24).toSeconds()), eq(TimeUnit.SECONDS));
-        }
+        assertThat(zsetByKey).containsOnlyKeys("match:ids:v1:p3");
+        RScoredSortedSetAsync<String> requesterZset = zsetByKey.get("match:ids:v1:p3");
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, Double>> membersCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(requesterZset).addAllAsync(membersCaptor.capture());
+        assertThat(membersCaptor.getValue())
+                .containsOnly(entry("KR_1", 100.0), entry("KR_2", 200.0), entry("KR_3", 300.0));
+
+        verify(requesterZset, times(1)).removeRangeByRankAsync(0, -21);
+        verify(keys, times(1)).expireAsync(eq("match:ids:v1:p3"),
+                eq(Duration.ofMinutes(3).toSeconds()), eq(TimeUnit.SECONDS));
 
         assertThat(meterRegistry.counter("cache.match.write", "result", "success").count())
-                .isEqualTo(1.0);
-        assertThat(meterRegistry.counter("cache.match.write", "result", "failure").count())
-                .isEqualTo(0.0);
+                .isEqualTo(3.0);
     }
 
     @Test
-    @DisplayName("RBatch.execute 가 실패해도 예외를 swallow 하고 failure 카운터를 증가시킨다")
-    void writeMatch_swallowsException() {
+    @DisplayName("요청자가 참가자가 아니어도 그 요청자의 ZSET 에 ZADD 한다")
+    void writeMatches_requesterNotInParticipants_stillAdds() {
+        adapter.writeMatches(List.of(buildMatch("KR_77", 1L)), "other-puuid");
+
+        assertThat(zsetByKey).containsOnlyKeys("match:ids:v1:other-puuid");
+    }
+
+    @Test
+    @DisplayName("RBatch.execute 실패 시 예외를 swallow + failure 카운터 증가")
+    void writeMatches_swallowsException() {
         when(batch.execute()).thenThrow(new RuntimeException("redis down"));
 
-        MatchDto match = buildMatch("KR_1", 1L, List.of("p0"));
-
-        adapter.writeMatch(match); // 예외 전파 X
+        adapter.writeMatches(List.of(buildMatch("KR_1", 1L), buildMatch("KR_2", 2L)), "p0");
 
         assertThat(meterRegistry.counter("cache.match.write", "result", "failure").count())
-                .isEqualTo(1.0);
+                .isEqualTo(2.0);
         assertThat(meterRegistry.counter("cache.match.write", "result", "success").count())
                 .isEqualTo(0.0);
     }
 
     @Test
-    @DisplayName("metadata 가 null 이면 아무 일도 일어나지 않는다")
-    void writeMatch_skipsWhenMetadataMissing() {
-        MatchDto match = new MatchDto();
-        match.setInfo(new InfoDto());
+    @DisplayName("리스트 내 invalid 매치는 skip 하고 나머지는 처리한다")
+    void writeMatches_skipsInvalidAndProcessesRest() {
+        MatchDto valid = buildMatch("KR_OK", 100L);
+        MatchDto noMetadata = new MatchDto();
+        noMetadata.setInfo(new InfoDto());
+        MatchDto blankId = buildMatch("", 200L);
 
-        adapter.writeMatch(match);
+        adapter.writeMatches(java.util.Arrays.asList(valid, null, noMetadata, blankId), "p0");
+
+        assertThat(bucketByKey).containsOnlyKeys("match:v1:KR_OK");
+        assertThat(meterRegistry.counter("cache.match.write", "result", "success").count())
+                .isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("매치 리스트가 비어있으면 아무 일도 일어나지 않는다")
+    void writeMatches_skipsWhenEmpty() {
+        adapter.writeMatches(Collections.emptyList(), "p0");
+        adapter.writeMatches(null, "p0");
 
         verify(redissonClient, times(0)).createBatch();
     }
 
     @Test
-    @DisplayName("matchId 가 비어있으면 아무 일도 일어나지 않는다")
-    void writeMatch_skipsWhenMatchIdBlank() {
-        MatchDto match = buildMatch("", 1L, List.of("p0"));
-
-        adapter.writeMatch(match);
+    @DisplayName("requesterPuuid 가 null 또는 blank 면 warn 로그 + skipped 메트릭")
+    void writeMatches_warnsOnBlankRequester() {
+        adapter.writeMatches(List.of(buildMatch("KR_5", 1L)), null);
+        adapter.writeMatches(List.of(buildMatch("KR_5", 1L)), "");
+        adapter.writeMatches(List.of(buildMatch("KR_5", 1L)), "   ");
 
         verify(redissonClient, times(0)).createBatch();
+        assertThat(meterRegistry.counter("cache.match.write", "result", "skipped").count())
+                .isEqualTo(3.0);
     }
 
     @Test
-    @DisplayName("null 매치는 NPE 없이 무시된다")
-    void writeMatch_nullSafe() {
-        adapter.writeMatch(null);
+    @DisplayName("리스트 안 매치가 모두 invalid 면 batch.execute 호출 안 함")
+    void writeMatches_skipsWhenAllInvalid() {
+        adapter.writeMatches(java.util.Arrays.asList((MatchDto) null, buildMatch("", 1L)), "p0");
 
-        verify(redissonClient, times(0)).createBatch();
+        verify(batch, times(0)).execute();
     }
 
-    @Test
-    @DisplayName("blank puuid 는 ZADD 대상에서 제외된다")
-    void writeMatch_skipsBlankPuuid() {
-        MatchDto match = buildMatch("KR_99", 100L, new ArrayList<>(List.of("p0", "", "p1")));
-
-        adapter.writeMatch(match);
-
-        assertThat(zsetByKey).containsOnlyKeys("match:ids:v1:p0", "match:ids:v1:p1");
-        verify(batch, atLeastOnce()).execute();
+    private String jsonContaining(String matchId) {
+        return org.mockito.ArgumentMatchers.argThat(json ->
+                json != null && json.contains("\"matchId\":\"" + matchId + "\""));
     }
 
-    private MatchDto buildMatch(String matchId, long gameCreation, List<String> puuids) {
+    private MatchDto buildMatch(String matchId, long gameCreation) {
         MatchDto match = new MatchDto();
         MetadataDto metadata = new MetadataDto();
         metadata.setMatchId(matchId);
@@ -164,13 +181,6 @@ class MatchCacheWriteAdapterTest {
 
         InfoDto info = new InfoDto();
         info.setGameCreation(gameCreation);
-        List<ParticipantDto> participants = new ArrayList<>();
-        for (String puuid : puuids) {
-            ParticipantDto p = new ParticipantDto();
-            p.setPuuid(puuid);
-            participants.add(p);
-        }
-        info.setParticipants(participants);
         match.setInfo(info);
         return match;
     }

--- a/infra/riot-client/src/main/java/com/mmrtr/lol/infra/riot/config/AsyncConfig.java
+++ b/infra/riot-client/src/main/java/com/mmrtr/lol/infra/riot/config/AsyncConfig.java
@@ -57,6 +57,13 @@ public class AsyncConfig {
         return executor;
     }
 
+    @Bean
+    public Executor matchSaveExecutor() {
+        ThreadPoolTaskExecutor executor = newPlatformThreadPoolExecutor(10, 10, 0, "MatchSave-");
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        return executor;
+    }
+
     private ExecutorService newVirtualThreadExecutor(String prefix, long startIndex) {
         ExecutorService delegate = Executors.newThreadPerTaskExecutor(
                 Thread.ofVirtual()


### PR DESCRIPTION
## Summary

- **Redis 캐시 write 를 batch (1 RTT)** 로 통합: `writeMatch` 단건 호출 N 회 → `writeMatches(List, requesterPuuid)` 단일 RBatch. 20 매치 갱신 시 Redis 왕복 20 → 1, ZSET 명령 60 → 3.
- **DB 적재 비동기화**: 갱신 시 동기 DB save 제거. 새 `AsyncMatchSaver` 가 `matchSaveExecutor` 위에서 `CompletableFuture.runAsync` 로 fire-and-forget. 매 갱신이 독립 스레드를 잡으므로 공유 큐 적체로 인한 head-of-line blocking 없음.
- **갱신 흐름 분리**: Riot API fetch → Redis 동기 write-through (즉시 lol-server 가 hit) → DB 비동기 save (백그라운드 영속화). 사용자 응답 wallclock 에서 DB save 시간 제거.
- **API 단계별 소요 시간 로그**: `[갱신-API] fetchSummoner / collectAndAssemble / fetchNewMatchIds / fetchMatchDetails+Timelines` 단계별 `log.debug` + `[갱신 완료] 총 소요` `log.info` (try/finally 로 모든 경로 보장).
- **요청자 본인 ZSET 만 ZADD**: 다른 참가자의 `match:ids:v1:{puuid}` 는 건드리지 않아 "최근 갱신 유저만 캐시 hit" 정책 유지 (부분 ZSET 으로 인한 stale read 제거).
- TTL 통일 3분 (갱신 가능 쿨다운과 동기화), blank requesterPuuid 입력 시 `log.warn` + `skipped` 메트릭.

## 주요 변경 파일

| 파일 | 설명 |
|---|---|
| `core/domain/.../MatchCacheWritePort.java` | `writeMatch` 단건 → `writeMatches(List, requesterPuuid)` batch API |
| `infra/redis/.../MatchCacheWriteAdapter.java` | 단일 RBatch (N SET + 1 multi-ZADD + 1 TRIM + 1 EXPIRE), blank puuid warn + metric |
| `infra/rabbitmq/.../SummonerRenewalService.java` | DB 동기 → Redis 동기 + DB 비동기, 단계별 timing 로그, try/finally |
| `infra/rabbitmq/.../AsyncMatchSaver.java` (NEW) | `SaveMatchDataUseCase` 를 `matchSaveExecutor` 위에서 fire-and-forget |
| `infra/rabbitmq/.../MatchDataProcessor.java` | 비활성 listener 흐름에서 `MatchCacheWritePort` 의존 제거 |
| `infra/riot-client/.../AsyncConfig.java` | `matchSaveExecutor` bean 추가 (10 platform threads, CallerRunsPolicy) |
| Test files | 재작성 (`MatchCacheWriteAdapterTest`) + 신규 (`AsyncMatchSaverTest`) |

## Test plan

- [ ] `./gradlew :core:domain:check :infra:redis:check :infra:rabbitmq:check` 통과 확인
- [ ] 갱신 1회 트리거 후 Redis 키 확인
  - `docker exec lol-redis redis-cli --scan --pattern "match:v1:*"` → 신규 매치들 즉시 등장
  - `docker exec lol-redis redis-cli --scan --pattern "match:ids:v1:*"` → **요청자 puuid 1개만** 존재해야 함
  - `docker exec lol-redis redis-cli ZRANGE match:ids:v1:{본인puuid} 0 -1 WITHSCORES` → 매치 ID 목록 + gameCreation score
- [ ] 로그에서 `[갱신-API] fetchSummoner: Nms`, `[갱신-API] fetchMatchDetails+Timelines (parallel): Nms`, `[갱신 완료] 총 소요: Nms` 확인 (debug 레벨 활성화 필요)
- [ ] 갱신 후 수초 안에 DB `match` 테이블에 적재 확인 (`MatchSave-N` 스레드명 로그)
- [ ] lol-server 에서 본인 매치 리스트 조회 시 ZSET hit → 단건 캐시 hit (DB 조회 없음) 동작 확인

## Known follow-ups (이 PR 범위 외)

- `MatchListener` / `MatchDataProcessor` / `MatchBatchProcessor` 비활성 체인 정리 (별도 PR)
- `MdcAwareExecutorService` 를 platform thread 풀 (`matchSaveExecutor`, `timelineSaveExecutor`) 에도 적용해 traceId 전파 (pre-existing inconsistency)
- HikariCP pool 사이즈 vs executor 스레드 수 검토 (부하 테스트 기반)