### PR TITLE
refactor(match): GameReadModel 형태로 캐시 JSON 쓰기 (write-side 변환)

### DIFF
--- a/core/domain/src/main/java/com/mmrtr/lol/domain/match/application/port/MatchCacheWritePort.java
+++ b/core/domain/src/main/java/com/mmrtr/lol/domain/match/application/port/MatchCacheWritePort.java
@@ -1,6 +1,7 @@
 package com.mmrtr.lol.domain.match.application.port;
 
 import com.mmrtr.lol.domain.match.readmodel.MatchDto;
+import com.mmrtr.lol.domain.match.readmodel.timeline.TimelineDto;
 
 import java.util.List;
 
@@ -15,10 +16,12 @@ public interface MatchCacheWritePort {
 
     /**
      * 단건 매치(`match:v1:{matchId}`) N 개와 요청자 puuid 의 매치 ID ZSET(`match:ids:v1:{requesterPuuid}`) 을
-     * 한 번의 Redis pipeline 으로 기록한다. 호출은 best-effort 이며 예외를 호출자에게 전파하지 않는다.
+     * 한 번의 Redis pipeline 으로 기록한다. 매치 단건은 lol-server 의 GameReadModel 형태로 직렬화되며,
+     * timeline 에서 itemSeq/skillSeq 를 추출해 포함한다. 호출은 best-effort 이며 예외를 전파하지 않는다.
      *
-     * @param matches         Riot API 에서 받아 파싱한 매치 DTO 목록 (각 metadata.matchId, info.gameCreation 필요)
+     * @param matches         Riot API 매치 DTO 목록 (각 metadata.matchId, info 필요)
+     * @param timelines       각 매치에 index 정렬된 timeline DTO 목록 (itemSeq/skillSeq 추출용, null 허용)
      * @param requesterPuuid  갱신을 요청한 유저의 puuid. 이 puuid 의 ZSET 에만 매치 ID 가 추가된다.
      */
-    void writeMatches(List<MatchDto> matches, String requesterPuuid);
+    void writeMatches(List<MatchDto> matches, List<TimelineDto> timelines, String requesterPuuid);
 }

--- a/infra/rabbitmq/src/main/java/com/mmrtr/lol/infra/rabbitmq/service/SummonerRenewalService.java
+++ b/infra/rabbitmq/src/main/java/com/mmrtr/lol/infra/rabbitmq/service/SummonerRenewalService.java
@@ -50,7 +50,7 @@ public class SummonerRenewalService {
     private void doRenew(String puuid, Platform platform) {
         long t = System.currentTimeMillis();
         SummonerDto summonerDto = summonerDataCollector.fetchSummoner(puuid, platform, requestExecutor);
-        log.debug("[갱신-API] fetchSummoner: {}ms puuid={}", System.currentTimeMillis() - t, puuid);
+        log.info("[갱신-API] fetchSummoner: {}ms puuid={}", System.currentTimeMillis() - t, puuid);
         if (summonerDto == null) {
             log.error("RIOT API에서 소환사 정보를 조회할 수 없습니다. puuid: {}", puuid);
             return;
@@ -65,7 +65,7 @@ public class SummonerRenewalService {
         t = System.currentTimeMillis();
         Optional<Summoner> summonerOpt = summonerDataCollector
                 .collectAndAssemble(puuid, platform, summonerDto, requestExecutor);
-        log.debug("[갱신-API] collectAndAssemble: {}ms puuid={}", System.currentTimeMillis() - t, puuid);
+        log.info("[갱신-API] collectAndAssemble: {}ms puuid={}", System.currentTimeMillis() - t, puuid);
         if (summonerOpt.isEmpty()) {
             return;
         }
@@ -74,7 +74,7 @@ public class SummonerRenewalService {
         t = System.currentTimeMillis();
         FetchNewMatchIdsResult fetchResult = matchDataFetcher
                 .fetchNewMatchIds(puuid, platform, revisionCheck.dbRevisionDateSeconds(), requestExecutor).join();
-        log.debug("[갱신-API] fetchNewMatchIds: {}ms count={} puuid={}",
+        log.info("[갱신-API] fetchNewMatchIds: {}ms count={} puuid={}",
                 System.currentTimeMillis() - t, fetchResult.newMatchIds().size(), puuid);
 
         t = System.currentTimeMillis();
@@ -85,14 +85,14 @@ public class SummonerRenewalService {
 
         List<MatchDto> matchDtos = matchDetailsFuture.join();
         List<TimelineDto> timelineDtos = timelinesFuture.join();
-        log.debug("[갱신-API] fetchMatchDetails+Timelines (parallel): {}ms count={} puuid={}",
+        log.info("[갱신-API] fetchMatchDetails+Timelines (parallel): {}ms count={} puuid={}",
                 System.currentTimeMillis() - t, matchDtos.size(), puuid);
 
         summoner.updateLastRiotCallDate();
         summonerDataCollector.save(summoner);
 
         if (matchDtos != null && !matchDtos.isEmpty()) {
-            matchCacheWritePort.writeMatches(matchDtos, puuid);
+            matchCacheWritePort.writeMatches(matchDtos, timelineDtos, puuid);
             asyncMatchSaver.saveAsync(matchDtos, timelineDtos);
         }
 

--- a/infra/redis/src/main/java/com/mmrtr/lol/infra/redis/adapter/MatchCacheWriteAdapter.java
+++ b/infra/redis/src/main/java/com/mmrtr/lol/infra/redis/adapter/MatchCacheWriteAdapter.java
@@ -5,6 +5,9 @@ import com.mmrtr.lol.domain.match.application.port.MatchCacheWritePort;
 import com.mmrtr.lol.domain.match.readmodel.InfoDto;
 import com.mmrtr.lol.domain.match.readmodel.MatchDto;
 import com.mmrtr.lol.domain.match.readmodel.MetadataDto;
+import com.mmrtr.lol.domain.match.readmodel.timeline.TimelineDto;
+import com.mmrtr.lol.infra.redis.adapter.view.MatchCacheView;
+import com.mmrtr.lol.infra.redis.adapter.view.MatchCacheViewMapper;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RBatch;
@@ -23,7 +26,7 @@ import java.util.concurrent.TimeUnit;
  *
  * <p>저장 키:
  * <ul>
- *   <li>{@code match:v1:{matchId}} - 단건 매치 JSON, 3분 TTL (모든 유저 공유)</li>
+ *   <li>{@code match:v1:{matchId}} - lol-server GameReadModel 형태로 직렬화된 단건 매치 JSON, 3분 TTL (공유)</li>
  *   <li>{@code match:ids:v1:{requesterPuuid}} - 갱신 요청자 ZSET (score = gameCreation),
  *       크기 20 으로 trim, 3분 TTL. 다른 참가자의 ZSET 은 채우지 않아 "최근 갱신 유저만 캐시" 유지</li>
  * </ul>
@@ -43,19 +46,22 @@ public class MatchCacheWriteAdapter implements MatchCacheWritePort {
     private final RedissonClient redissonClient;
     private final ObjectMapper objectMapper;
     private final MeterRegistry meterRegistry;
+    private final MatchCacheViewMapper viewMapper;
 
     public MatchCacheWriteAdapter(
             RedissonClient redissonClient,
             ObjectMapper objectMapper,
-            MeterRegistry meterRegistry
+            MeterRegistry meterRegistry,
+            MatchCacheViewMapper viewMapper
     ) {
         this.redissonClient = redissonClient;
         this.objectMapper = objectMapper;
         this.meterRegistry = meterRegistry;
+        this.viewMapper = viewMapper;
     }
 
     @Override
-    public void writeMatches(List<MatchDto> matches, String requesterPuuid) {
+    public void writeMatches(List<MatchDto> matches, List<TimelineDto> timelines, String requesterPuuid) {
         if (matches == null || matches.isEmpty()) {
             return;
         }
@@ -69,12 +75,16 @@ public class MatchCacheWriteAdapter implements MatchCacheWritePort {
             RBatch batch = redissonClient.createBatch();
             Map<String, Double> zsetMembers = new HashMap<>();
 
-            for (MatchDto match : matches) {
+            for (int i = 0; i < matches.size(); i++) {
+                MatchDto match = matches.get(i);
                 String matchId = extractMatchId(match);
                 if (matchId == null) {
                     continue;
                 }
-                String json = objectMapper.writeValueAsString(match);
+                TimelineDto timeline = (timelines != null && i < timelines.size()) ? timelines.get(i) : null;
+                MatchCacheView view = viewMapper.toView(match, timeline);
+
+                String json = objectMapper.writeValueAsString(view);
                 batch.getBucket(MATCH_KEY_PREFIX + matchId, StringCodec.INSTANCE)
                         .setAsync(json, MATCH_TTL);
                 zsetMembers.put(matchId, (double) match.getInfo().getGameCreation());

--- a/infra/redis/src/main/java/com/mmrtr/lol/infra/redis/adapter/view/GameInfoView.java
+++ b/infra/redis/src/main/java/com/mmrtr/lol/infra/redis/adapter/view/GameInfoView.java
@@ -1,0 +1,24 @@
+package com.mmrtr.lol.infra.redis.adapter.view;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GameInfoView {
+    private String dataVersion;
+    private long gameCreation;
+    private long gameDuration;
+    private long gameEndTimestamp;
+    private String gameMode;
+    private long gameStartTimestamp;
+    private String gameType;
+    private String gameVersion;
+    private int mapId;
+    private String platformId;
+    private int queueId;
+    private String tournamentCode;
+    private String matchId;
+    private String averageTier;
+    private String averageRank;
+}

--- a/infra/redis/src/main/java/com/mmrtr/lol/infra/redis/adapter/view/ItemSeqView.java
+++ b/infra/redis/src/main/java/com/mmrtr/lol/infra/redis/adapter/view/ItemSeqView.java
@@ -1,0 +1,12 @@
+package com.mmrtr.lol.infra.redis.adapter.view;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ItemSeqView {
+    private int itemId;
+    private long minute;
+    private String type;
+}

--- a/infra/redis/src/main/java/com/mmrtr/lol/infra/redis/adapter/view/ItemView.java
+++ b/infra/redis/src/main/java/com/mmrtr/lol/infra/redis/adapter/view/ItemView.java
@@ -1,0 +1,16 @@
+package com.mmrtr.lol.infra.redis.adapter.view;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ItemView {
+    private int item0;
+    private int item1;
+    private int item2;
+    private int item3;
+    private int item4;
+    private int item5;
+    private int item6;
+}

--- a/infra/redis/src/main/java/com/mmrtr/lol/infra/redis/adapter/view/MatchCacheView.java
+++ b/infra/redis/src/main/java/com/mmrtr/lol/infra/redis/adapter/view/MatchCacheView.java
@@ -1,0 +1,18 @@
+package com.mmrtr.lol.infra.redis.adapter.view;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * lol-server 의 {@code GameReadModel} JSON 형태를 그대로 미러링한 캐시 쓰기 전용 view.
+ * lol-server 는 이 JSON 을 변환 없이 GameReadModel 로 역직렬화한다. 필드명은 GameReadModel 트리와 1:1 일치해야 한다.
+ */
+@Getter
+@Builder
+public class MatchCacheView {
+    private GameInfoView gameInfoData;
+    private List<ParticipantView> participantData;
+    private TeamView teamInfoData;
+}

--- a/infra/redis/src/main/java/com/mmrtr/lol/infra/redis/adapter/view/MatchCacheViewMapper.java
+++ b/infra/redis/src/main/java/com/mmrtr/lol/infra/redis/adapter/view/MatchCacheViewMapper.java
@@ -1,0 +1,277 @@
+package com.mmrtr.lol.infra.redis.adapter.view;
+
+import com.mmrtr.lol.domain.match.readmodel.ChallengesDto;
+import com.mmrtr.lol.domain.match.readmodel.InfoDto;
+import com.mmrtr.lol.domain.match.readmodel.MatchDto;
+import com.mmrtr.lol.domain.match.readmodel.MetadataDto;
+import com.mmrtr.lol.domain.match.readmodel.ObjectiveDto;
+import com.mmrtr.lol.domain.match.readmodel.ObjectivesDto;
+import com.mmrtr.lol.domain.match.readmodel.ParticipantDto;
+import com.mmrtr.lol.domain.match.readmodel.PerksDto;
+import com.mmrtr.lol.domain.match.readmodel.PerkStatsDto;
+import com.mmrtr.lol.domain.match.readmodel.PerkStyleDto;
+import com.mmrtr.lol.domain.match.readmodel.PerkStyleSelectionDto;
+import com.mmrtr.lol.domain.match.readmodel.TeamDto;
+import com.mmrtr.lol.domain.match.readmodel.timeline.EventsTimeLineDto;
+import com.mmrtr.lol.domain.match.readmodel.timeline.FramesTimeLineDto;
+import com.mmrtr.lol.domain.match.readmodel.timeline.TimelineDto;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Riot {@link MatchDto} + {@link TimelineDto} 를 lol-server 의 GameReadModel 형태({@link MatchCacheView})로 변환한다.
+ * <p>
+ * DB 전용 필드(tier/averageTier 등)와 풀 timeline 전용 필드(goldTimeline/timestamps)는 채우지 않는다.
+ * itemSeq 는 {@code ITEM_PURCHASED}, skillSeq 는 {@code SKILL_LEVEL_UP} 이벤트만 추출한다 (DB 리스트 경로와 동일).
+ */
+@Component
+public class MatchCacheViewMapper {
+
+    private static final int BLUE_TEAM_ID = 100;
+    private static final int RED_TEAM_ID = 200;
+    private static final String ITEM_PURCHASED = "ITEM_PURCHASED";
+    private static final String SKILL_LEVEL_UP = "SKILL_LEVEL_UP";
+
+    public MatchCacheView toView(MatchDto match, TimelineDto timeline) {
+        InfoDto info = match.getInfo();
+        MetadataDto metadata = match.getMetadata();
+
+        ItemSkillSeq seq = extractSeq(timeline);
+
+        return MatchCacheView.builder()
+                .gameInfoData(toGameInfo(metadata, info))
+                .participantData(toParticipants(info, seq))
+                .teamInfoData(toTeam(info))
+                .build();
+    }
+
+    private GameInfoView toGameInfo(MetadataDto metadata, InfoDto info) {
+        return GameInfoView.builder()
+                .matchId(metadata == null ? null : metadata.getMatchId())
+                .dataVersion(metadata == null ? null : metadata.getDataVersion())
+                .gameCreation(info.getGameCreation())
+                .gameDuration(info.getGameDuration())
+                .gameEndTimestamp(info.getGameEndTimestamp())
+                .gameStartTimestamp(info.getGameStartTimestamp())
+                .gameMode(info.getGameMode())
+                .gameType(info.getGameType())
+                .gameVersion(info.getGameVersion())
+                .mapId(info.getMapId())
+                .platformId(info.getPlatformId())
+                .queueId(info.getQueueId())
+                .tournamentCode(info.getTournamentCode())
+                .build();
+    }
+
+    private List<ParticipantView> toParticipants(InfoDto info, ItemSkillSeq seq) {
+        List<ParticipantView> result = new ArrayList<>();
+        if (info.getParticipants() == null) {
+            return result;
+        }
+        for (ParticipantDto p : info.getParticipants()) {
+            result.add(toParticipant(p, seq));
+        }
+        return result;
+    }
+
+    private ParticipantView toParticipant(ParticipantDto p, ItemSkillSeq seq) {
+        ChallengesDto c = p.getChallenges();
+        return baseBuilder(p)
+                .item(toItem(p))
+                .style(toStyle(p.getPerks()))
+                .statValue(toStat(p.getPerks()))
+                .kda(c != null ? c.getKda() : computeKda(p))
+                .teamDamagePercentage(c != null ? c.getTeamDamagePercentage() : 0.0)
+                .goldPerMinute(c != null ? c.getGoldPerMinute() : 0.0)
+                .killParticipation(c != null ? c.getKillParticipation() : 0.0)
+                .itemSeq(seq.items.getOrDefault(p.getParticipantId(), List.of()))
+                .skillSeq(seq.skills.getOrDefault(p.getParticipantId(), List.of()))
+                .build();
+    }
+
+    private ParticipantView.ParticipantViewBuilder baseBuilder(ParticipantDto p) {
+        return ParticipantView.builder()
+                .profileIcon(p.getProfileIcon())
+                .riotIdGameName(p.getRiotIdGameName())
+                .riotIdTagline(p.getRiotIdTagline())
+                .puuid(p.getPuuid())
+                .summonerLevel(p.getSummonerLevel())
+                .summonerId(p.getSummonerId())
+                .individualPosition(p.getIndividualPosition())
+                .kills(p.getKills())
+                .deaths(p.getDeaths())
+                .assists(p.getAssists())
+                .champExperience(p.getChampExperience())
+                .champLevel(p.getChampLevel())
+                .championId(p.getChampionId())
+                .championName(p.getChampionName())
+                .consumablesPurchased(p.getConsumablesPurchased())
+                .goldEarned(p.getGoldEarned())
+                .summoner1Id(p.getSummoner1Id())
+                .summoner2Id(p.getSummoner2Id())
+                .itemsPurchased(p.getItemsPurchased())
+                .participantId(p.getParticipantId())
+                .visionScore(p.getVisionScore())
+                .totalMinionsKilled(p.getTotalMinionsKilled())
+                .neutralMinionsKilled(p.getNeutralMinionsKilled())
+                .totalDamageDealtToChampions(p.getTotalDamageDealtToChampions())
+                .totalDamageTaken(p.getTotalDamageTaken())
+                .visionWardsBoughtInGame(p.getVisionWardsBoughtInGame())
+                .wardsKilled(p.getWardsKilled())
+                .wardsPlaced(p.getWardsPlaced())
+                .doubleKills(p.getDoubleKills())
+                .tripleKills(p.getTripleKills())
+                .quadraKills(p.getQuadraKills())
+                .pentaKills(p.getPentaKills())
+                .teamId(p.getTeamId())
+                .teamPosition(p.getTeamPosition())
+                .win(p.isWin())
+                .timePlayed(p.getTimePlayed())
+                .timeCCingOthers(p.getTimeCCingOthers())
+                .lane(p.getLane())
+                .role(p.getRole())
+                .placement(p.getPlacement())
+                .playerAugment1(p.getPlayerAugment1())
+                .playerAugment2(p.getPlayerAugment2())
+                .playerAugment3(p.getPlayerAugment3())
+                .playerAugment4(p.getPlayerAugment4());
+    }
+
+    private double computeKda(ParticipantDto p) {
+        int deaths = Math.max(1, p.getDeaths());
+        return (p.getKills() + p.getAssists()) / (double) deaths;
+    }
+
+    private ItemView toItem(ParticipantDto p) {
+        return ItemView.builder()
+                .item0(p.getItem0())
+                .item1(p.getItem1())
+                .item2(p.getItem2())
+                .item3(p.getItem3())
+                .item4(p.getItem4())
+                .item5(p.getItem5())
+                .item6(p.getItem6())
+                .build();
+    }
+
+    private StyleView toStyle(PerksDto perks) {
+        StyleView.StyleViewBuilder b = StyleView.builder();
+        if (perks == null || perks.getStyles() == null || perks.getStyles().isEmpty()) {
+            return b.build();
+        }
+        List<PerkStyleDto> styles = perks.getStyles();
+        PerkStyleDto primary = styles.get(0);
+        b.primaryStyleId(primary.getStyle())
+                .primaryPerk0(perkAt(primary, 0))
+                .primaryPerk1(perkAt(primary, 1))
+                .primaryPerk2(perkAt(primary, 2))
+                .primaryPerk3(perkAt(primary, 3));
+        if (styles.size() > 1) {
+            PerkStyleDto sub = styles.get(1);
+            b.subStyleId(sub.getStyle())
+                    .subPerk0(perkAt(sub, 0))
+                    .subPerk1(perkAt(sub, 1));
+        }
+        return b.build();
+    }
+
+    private int perkAt(PerkStyleDto style, int idx) {
+        List<PerkStyleSelectionDto> selections = style.getSelections();
+        if (selections == null || idx >= selections.size() || selections.get(idx) == null) {
+            return 0;
+        }
+        return selections.get(idx).getPerk();
+    }
+
+    private StatView toStat(PerksDto perks) {
+        if (perks == null || perks.getStatPerks() == null) {
+            return StatView.builder().build();
+        }
+        PerkStatsDto sp = perks.getStatPerks();
+        return StatView.builder()
+                .defense(sp.getDefense())
+                .flex(sp.getFlex())
+                .offense(sp.getOffense())
+                .build();
+    }
+
+    private TeamView toTeam(InfoDto info) {
+        if (info.getTeams() == null || info.getTeams().isEmpty()) {
+            return TeamView.builder().build();
+        }
+        return TeamView.builder()
+                .blueTeam(toTeamInfo(findTeam(info, BLUE_TEAM_ID)))
+                .redTeam(toTeamInfo(findTeam(info, RED_TEAM_ID)))
+                .build();
+    }
+
+    private TeamDto findTeam(InfoDto info, int teamId) {
+        for (TeamDto t : info.getTeams()) {
+            if (t != null && t.getTeamId() == teamId) {
+                return t;
+            }
+        }
+        return null;
+    }
+
+    private TeamInfoView toTeamInfo(TeamDto team) {
+        TeamInfoView.TeamInfoViewBuilder b = TeamInfoView.builder();
+        if (team == null) {
+            return b.build();
+        }
+        b.teamId(team.getTeamId()).win(team.isWin());
+        ObjectivesDto obj = team.getObjectives();
+        if (obj != null) {
+            b.championKills(kills(obj.getChampion()))
+                    .baronKills(kills(obj.getBaron()))
+                    .dragonKills(kills(obj.getDragon()))
+                    .towerKills(kills(obj.getTower()))
+                    .inhibitorKills(kills(obj.getInhibitor()));
+        }
+        return b.build();
+    }
+
+    private int kills(ObjectiveDto objective) {
+        return objective == null ? 0 : objective.getKills();
+    }
+
+    private ItemSkillSeq extractSeq(TimelineDto timeline) {
+        ItemSkillSeq seq = new ItemSkillSeq();
+        if (timeline == null || timeline.getInfo() == null || timeline.getInfo().getFrames() == null) {
+            return seq;
+        }
+        for (FramesTimeLineDto frame : timeline.getInfo().getFrames()) {
+            if (frame.getEvents() == null) {
+                continue;
+            }
+            for (EventsTimeLineDto e : frame.getEvents()) {
+                String type = e.getType();
+                if (ITEM_PURCHASED.equals(type)) {
+                    seq.items.computeIfAbsent(e.getParticipantId(), k -> new ArrayList<>())
+                            .add(ItemSeqView.builder()
+                                    .itemId(e.getItemId())
+                                    .minute(e.getTimestamp() / 1000 / 60)
+                                    .type(type)
+                                    .build());
+                } else if (SKILL_LEVEL_UP.equals(type)) {
+                    seq.skills.computeIfAbsent(e.getParticipantId(), k -> new ArrayList<>())
+                            .add(SkillSeqView.builder()
+                                    .skillSlot(e.getSkillSlot())
+                                    .minute(e.getTimestamp() / 1000 / 60)
+                                    .type(type)
+                                    .build());
+                }
+            }
+        }
+        return seq;
+    }
+
+    private static final class ItemSkillSeq {
+        private final Map<Integer, List<ItemSeqView>> items = new HashMap<>();
+        private final Map<Integer, List<SkillSeqView>> skills = new HashMap<>();
+    }
+}

--- a/infra/redis/src/main/java/com/mmrtr/lol/infra/redis/adapter/view/ParticipantView.java
+++ b/infra/redis/src/main/java/com/mmrtr/lol/infra/redis/adapter/view/ParticipantView.java
@@ -1,0 +1,74 @@
+package com.mmrtr.lol.infra.redis.adapter.view;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ParticipantView {
+    private int profileIcon;
+    private String riotIdGameName;
+    private String riotIdTagline;
+    private String puuid;
+    private int summonerLevel;
+    private String summonerId;
+    private String tier;
+    private String tierRank;
+    private Integer absolutePoints;
+
+    private String individualPosition;
+    private int kills;
+    private int deaths;
+    private int assists;
+    private int champExperience;
+    private int champLevel;
+    private int championId;
+    private String championName;
+    private int consumablesPurchased;
+    private int goldEarned;
+    private ItemView item;
+    private int summoner1Id;
+    private int summoner2Id;
+    private int itemsPurchased;
+    private int participantId;
+    private StatView statValue;
+    private StyleView style;
+    private int visionScore;
+    private int totalMinionsKilled;
+    private int neutralMinionsKilled;
+    private int totalDamageDealtToChampions;
+    private int totalDamageTaken;
+    private int visionWardsBoughtInGame;
+    private int wardsKilled;
+    private int wardsPlaced;
+
+    private int doubleKills;
+    private int tripleKills;
+    private int quadraKills;
+    private int pentaKills;
+
+    private double kda;
+    private double teamDamagePercentage;
+    private double goldPerMinute;
+    private double killParticipation;
+
+    private int teamId;
+    private String teamPosition;
+    private boolean win;
+
+    private int timePlayed;
+    private int timeCCingOthers;
+    private String lane;
+    private String role;
+
+    private int placement;
+    private int playerAugment1;
+    private int playerAugment2;
+    private int playerAugment3;
+    private int playerAugment4;
+
+    private List<ItemSeqView> itemSeq;
+    private List<SkillSeqView> skillSeq;
+}

--- a/infra/redis/src/main/java/com/mmrtr/lol/infra/redis/adapter/view/SkillSeqView.java
+++ b/infra/redis/src/main/java/com/mmrtr/lol/infra/redis/adapter/view/SkillSeqView.java
@@ -1,0 +1,12 @@
+package com.mmrtr.lol.infra.redis.adapter.view;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SkillSeqView {
+    private int skillSlot;
+    private long minute;
+    private String type;
+}

--- a/infra/redis/src/main/java/com/mmrtr/lol/infra/redis/adapter/view/StatView.java
+++ b/infra/redis/src/main/java/com/mmrtr/lol/infra/redis/adapter/view/StatView.java
@@ -1,0 +1,12 @@
+package com.mmrtr.lol.infra.redis.adapter.view;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class StatView {
+    private int defense;
+    private int flex;
+    private int offense;
+}

--- a/infra/redis/src/main/java/com/mmrtr/lol/infra/redis/adapter/view/StyleView.java
+++ b/infra/redis/src/main/java/com/mmrtr/lol/infra/redis/adapter/view/StyleView.java
@@ -1,0 +1,17 @@
+package com.mmrtr.lol.infra.redis.adapter.view;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class StyleView {
+    private int primaryStyleId;
+    private int primaryPerk0;
+    private int primaryPerk1;
+    private int primaryPerk2;
+    private int primaryPerk3;
+    private int subStyleId;
+    private int subPerk0;
+    private int subPerk1;
+}

--- a/infra/redis/src/main/java/com/mmrtr/lol/infra/redis/adapter/view/TeamInfoView.java
+++ b/infra/redis/src/main/java/com/mmrtr/lol/infra/redis/adapter/view/TeamInfoView.java
@@ -1,0 +1,16 @@
+package com.mmrtr.lol.infra.redis.adapter.view;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TeamInfoView {
+    private int teamId;
+    private boolean win;
+    private int championKills;
+    private int baronKills;
+    private int dragonKills;
+    private int towerKills;
+    private int inhibitorKills;
+}

--- a/infra/redis/src/main/java/com/mmrtr/lol/infra/redis/adapter/view/TeamView.java
+++ b/infra/redis/src/main/java/com/mmrtr/lol/infra/redis/adapter/view/TeamView.java
@@ -1,0 +1,11 @@
+package com.mmrtr.lol.infra.redis.adapter.view;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TeamView {
+    private TeamInfoView blueTeam;
+    private TeamInfoView redTeam;
+}

--- a/infra/redis/src/test/java/com/mmrtr/lol/infra/redis/adapter/MatchCacheWriteAdapterTest.java
+++ b/infra/redis/src/test/java/com/mmrtr/lol/infra/redis/adapter/MatchCacheWriteAdapterTest.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mmrtr.lol.domain.match.readmodel.InfoDto;
 import com.mmrtr.lol.domain.match.readmodel.MatchDto;
 import com.mmrtr.lol.domain.match.readmodel.MetadataDto;
+import com.mmrtr.lol.domain.match.readmodel.ParticipantDto;
+import com.mmrtr.lol.infra.redis.adapter.view.MatchCacheViewMapper;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,6 +20,8 @@ import org.redisson.api.RedissonClient;
 import org.redisson.client.codec.Codec;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -67,72 +71,66 @@ class MatchCacheWriteAdapterTest {
 
         meterRegistry = new SimpleMeterRegistry();
         objectMapper = new ObjectMapper();
-        adapter = new MatchCacheWriteAdapter(redissonClient, objectMapper, meterRegistry);
+        adapter = new MatchCacheWriteAdapter(
+                redissonClient, objectMapper, meterRegistry, new MatchCacheViewMapper());
     }
 
     @Test
-    @DisplayName("N 매치 SET + 요청자 ZSET 1개 ZADD/TRIM/EXPIRE 가 단일 batch 로 실행된다")
-    void writeMatches_singleBatchForAllMatches() {
-        MatchDto m1 = buildMatch("KR_1", 100L);
-        MatchDto m2 = buildMatch("KR_2", 200L);
-        MatchDto m3 = buildMatch("KR_3", 300L);
+    @DisplayName("N 매치는 GameReadModel 형태 JSON 으로 SET + 요청자 ZSET 1개에 ZADD/TRIM/EXPIRE 단일 batch")
+    void writeMatches_serializesViewAndSingleBatch() {
+        MatchDto m1 = buildMatch("KR_1", 100L, "Ahri");
+        MatchDto m2 = buildMatch("KR_2", 200L, "Caitlyn");
 
-        adapter.writeMatches(List.of(m1, m2, m3), "p3");
+        adapter.writeMatches(List.of(m1, m2), null, "p3");
 
         verify(batch, times(1)).execute();
+        assertThat(bucketByKey).containsOnlyKeys("match:v1:KR_1", "match:v1:KR_2");
 
-        assertThat(bucketByKey).containsOnlyKeys("match:v1:KR_1", "match:v1:KR_2", "match:v1:KR_3");
-        verify(bucketByKey.get("match:v1:KR_1")).setAsync(jsonContaining("KR_1"), eq(Duration.ofMinutes(3)));
-        verify(bucketByKey.get("match:v1:KR_2")).setAsync(jsonContaining("KR_2"), eq(Duration.ofMinutes(3)));
-        verify(bucketByKey.get("match:v1:KR_3")).setAsync(jsonContaining("KR_3"), eq(Duration.ofMinutes(3)));
+        // GameReadModel 형태인지 확인 (gameInfoData.matchId, participantData[].championName)
+        ArgumentCaptor<String> jsonCaptor = ArgumentCaptor.forClass(String.class);
+        verify(bucketByKey.get("match:v1:KR_1"))
+                .setAsync(jsonCaptor.capture(), eq(Duration.ofMinutes(3)));
+        String json = jsonCaptor.getValue();
+        assertThat(json).contains("\"gameInfoData\"");
+        assertThat(json).contains("\"matchId\":\"KR_1\"");
+        assertThat(json).contains("\"participantData\"");
+        assertThat(json).contains("\"championName\":\"Ahri\"");
+        assertThat(json).contains("\"teamInfoData\"");
 
         assertThat(zsetByKey).containsOnlyKeys("match:ids:v1:p3");
-        RScoredSortedSetAsync<String> requesterZset = zsetByKey.get("match:ids:v1:p3");
+        RScoredSortedSetAsync<String> zset = zsetByKey.get("match:ids:v1:p3");
 
         @SuppressWarnings("unchecked")
         ArgumentCaptor<Map<String, Double>> membersCaptor = ArgumentCaptor.forClass(Map.class);
-        verify(requesterZset).addAllAsync(membersCaptor.capture());
-        assertThat(membersCaptor.getValue())
-                .containsOnly(entry("KR_1", 100.0), entry("KR_2", 200.0), entry("KR_3", 300.0));
-
-        verify(requesterZset, times(1)).removeRangeByRankAsync(0, -21);
+        verify(zset).addAllAsync(membersCaptor.capture());
+        assertThat(membersCaptor.getValue()).containsOnly(entry("KR_1", 100.0), entry("KR_2", 200.0));
+        verify(zset, times(1)).removeRangeByRankAsync(0, -21);
         verify(keys, times(1)).expireAsync(eq("match:ids:v1:p3"),
                 eq(Duration.ofMinutes(3).toSeconds()), eq(TimeUnit.SECONDS));
 
         assertThat(meterRegistry.counter("cache.match.write", "result", "success").count())
-                .isEqualTo(3.0);
+                .isEqualTo(2.0);
     }
 
     @Test
-    @DisplayName("요청자가 참가자가 아니어도 그 요청자의 ZSET 에 ZADD 한다")
-    void writeMatches_requesterNotInParticipants_stillAdds() {
-        adapter.writeMatches(List.of(buildMatch("KR_77", 1L)), "other-puuid");
-
-        assertThat(zsetByKey).containsOnlyKeys("match:ids:v1:other-puuid");
-    }
-
-    @Test
-    @DisplayName("RBatch.execute 실패 시 예외를 swallow + failure 카운터 증가")
+    @DisplayName("RBatch.execute 실패 시 swallow + failure 카운터")
     void writeMatches_swallowsException() {
         when(batch.execute()).thenThrow(new RuntimeException("redis down"));
 
-        adapter.writeMatches(List.of(buildMatch("KR_1", 1L), buildMatch("KR_2", 2L)), "p0");
+        adapter.writeMatches(List.of(buildMatch("KR_1", 1L, "Ahri")), null, "p0");
 
         assertThat(meterRegistry.counter("cache.match.write", "result", "failure").count())
-                .isEqualTo(2.0);
-        assertThat(meterRegistry.counter("cache.match.write", "result", "success").count())
-                .isEqualTo(0.0);
+                .isEqualTo(1.0);
     }
 
     @Test
-    @DisplayName("리스트 내 invalid 매치는 skip 하고 나머지는 처리한다")
-    void writeMatches_skipsInvalidAndProcessesRest() {
-        MatchDto valid = buildMatch("KR_OK", 100L);
+    @DisplayName("invalid 매치는 skip 하고 나머지 처리")
+    void writeMatches_skipsInvalid() {
+        MatchDto valid = buildMatch("KR_OK", 100L, "Ahri");
         MatchDto noMetadata = new MatchDto();
         noMetadata.setInfo(new InfoDto());
-        MatchDto blankId = buildMatch("", 200L);
 
-        adapter.writeMatches(java.util.Arrays.asList(valid, null, noMetadata, blankId), "p0");
+        adapter.writeMatches(Arrays.asList(valid, null, noMetadata), null, "p0");
 
         assertThat(bucketByKey).containsOnlyKeys("match:v1:KR_OK");
         assertThat(meterRegistry.counter("cache.match.write", "result", "success").count())
@@ -142,38 +140,24 @@ class MatchCacheWriteAdapterTest {
     @Test
     @DisplayName("매치 리스트가 비어있으면 아무 일도 일어나지 않는다")
     void writeMatches_skipsWhenEmpty() {
-        adapter.writeMatches(Collections.emptyList(), "p0");
-        adapter.writeMatches(null, "p0");
+        adapter.writeMatches(Collections.emptyList(), null, "p0");
+        adapter.writeMatches(null, null, "p0");
 
         verify(redissonClient, times(0)).createBatch();
     }
 
     @Test
-    @DisplayName("requesterPuuid 가 null 또는 blank 면 warn 로그 + skipped 메트릭")
+    @DisplayName("requesterPuuid blank 면 warn + skipped 메트릭")
     void writeMatches_warnsOnBlankRequester() {
-        adapter.writeMatches(List.of(buildMatch("KR_5", 1L)), null);
-        adapter.writeMatches(List.of(buildMatch("KR_5", 1L)), "");
-        adapter.writeMatches(List.of(buildMatch("KR_5", 1L)), "   ");
+        adapter.writeMatches(List.of(buildMatch("KR_5", 1L, "Ahri")), null, null);
+        adapter.writeMatches(List.of(buildMatch("KR_5", 1L, "Ahri")), null, "  ");
 
         verify(redissonClient, times(0)).createBatch();
         assertThat(meterRegistry.counter("cache.match.write", "result", "skipped").count())
-                .isEqualTo(3.0);
+                .isEqualTo(2.0);
     }
 
-    @Test
-    @DisplayName("리스트 안 매치가 모두 invalid 면 batch.execute 호출 안 함")
-    void writeMatches_skipsWhenAllInvalid() {
-        adapter.writeMatches(java.util.Arrays.asList((MatchDto) null, buildMatch("", 1L)), "p0");
-
-        verify(batch, times(0)).execute();
-    }
-
-    private String jsonContaining(String matchId) {
-        return org.mockito.ArgumentMatchers.argThat(json ->
-                json != null && json.contains("\"matchId\":\"" + matchId + "\""));
-    }
-
-    private MatchDto buildMatch(String matchId, long gameCreation) {
+    private MatchDto buildMatch(String matchId, long gameCreation, String championName) {
         MatchDto match = new MatchDto();
         MetadataDto metadata = new MetadataDto();
         metadata.setMatchId(matchId);
@@ -181,6 +165,13 @@ class MatchCacheWriteAdapterTest {
 
         InfoDto info = new InfoDto();
         info.setGameCreation(gameCreation);
+        List<ParticipantDto> participants = new ArrayList<>();
+        ParticipantDto p = new ParticipantDto();
+        p.setPuuid("p0");
+        p.setChampionName(championName);
+        p.setParticipantId(1);
+        participants.add(p);
+        info.setParticipants(participants);
         match.setInfo(info);
         return match;
     }


### PR DESCRIPTION
## 배경
유저 전적 갱신 시 매치 데이터를 Redis 캐시에 write-through 하는데, 그동안 캐시 JSON 변환을 **읽기 측(lol-server)** 이 매 조회마다 수행해 CPU 를 낭비했다. (이전엔 직렬화 포맷 불일치로 캐시가 사실상 항상 miss → DB fallback)

이 PR 은 변환을 **쓰기 측(lol-repository)** 으로 옮긴다(1-C). lol-repository 가 lol-server 의 `GameReadModel` 과 동일한 형태로 캐시를 직렬화하므로, lol-server 는 변환 없이 `readValue(json, GameReadModel.class)` 한 번으로 읽는다. **가공 비용은 쓰기 때 1회만** 발생.

## 변경
- **view POJO 10개 + `MatchCacheViewMapper` 신규** (`infra/redis/.../adapter/view/`)
  - `GameReadModel` JSON 형태 1:1 미러
  - perks 평탄화(primary/sub), 팀 objectives 매핑
  - `itemSeq` = `ITEM_PURCHASED`, `skillSeq` = `SKILL_LEVEL_UP` 이벤트만 추출 (minute = ts/1000/60, DB 리스트 경로와 동일). 풀 타임라인의 수천 이벤트 중 필요한 것만 담아 캐시 슬림화
- `MatchCacheWritePort.writeMatches(matches, timelines, requesterPuuid)` — timeline 파라미터 추가
- `MatchCacheWriteAdapter` — viewMapper 로 변환 후 단일 RBatch 직렬화 (1 RTT)
- `SummonerRenewalService` — `writeMatches(matchDtos, timelineDtos, puuid)`

## 의도된 정보 손실 (캐시 hit 한정)
- `tier`/`averageTier` 등 DB 전용 필드, `goldTimeline`/`timestamps` 등 풀 타임라인 전용 필드는 캐시에 미포함. 3분 TTL 만료 후 DB 경로로 떨어지면 채워짐

## 검증
- `:core:domain:check :infra:redis:check :infra:rabbitmq:check` → BUILD SUCCESSFUL
- `MatchCacheWriteAdapterTest` 재작성: GameReadModel 형태 JSON 직렬화 + 요청자 ZSET ZADD/TRIM/EXPIRE 단일 batch 검증

## 관련
- 읽기 측: padosol/lol-server#112