### PR TITLE
refactor(MP-104): ConcurrencyInterceptor 추출 + statusHandler 분리 + 백오프 통일

### DIFF
--- a/infra/riot-client/src/main/java/com/mmrtr/lol/infra/riot/config/RiotApiConfig.java
+++ b/infra/riot-client/src/main/java/com/mmrtr/lol/infra/riot/config/RiotApiConfig.java
@@ -3,6 +3,7 @@ package com.mmrtr.lol.infra.riot.config;
 import com.mmrtr.lol.infra.riot.exception.RiotClientException;
 import com.mmrtr.lol.infra.riot.exception.RiotClientNotFoundException;
 import com.mmrtr.lol.infra.riot.exception.RiotServerException;
+import com.mmrtr.lol.infra.riot.interceptor.ConcurrencyInterceptor;
 import com.mmrtr.lol.infra.riot.interceptor.RateLimitInterceptor;
 import com.mmrtr.lol.infra.riot.interceptor.RetryInterceptor;
 import com.mmrtr.lol.infra.riot.ratelimit.HostRateLimitResolver;
@@ -14,21 +15,24 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.logging.LogLevel;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpRequest;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 
 import java.io.IOException;
 import java.net.http.HttpClient;
 import java.time.Duration;
-import java.util.concurrent.Semaphore;
 
 @Slf4j
 @Configuration
 @RequiredArgsConstructor
 @EnableConfigurationProperties(RiotAPIProperties.class)
 public class RiotApiConfig {
+
+    private static final int CONCURRENCY_LIMIT = 20;
 
     private final RiotAPIProperties riotAPIProperties;
     private final RedissonClient redissonClient;
@@ -47,21 +51,7 @@ public class RiotApiConfig {
         RetryInterceptor retryInterceptor = new RetryInterceptor(meterRegistry);
         RateLimitInterceptor rateLimitInterceptor = new RateLimitInterceptor(
                 redissonClient, hostRateLimitResolver);
-
-        Semaphore concurrencyLimiter = new Semaphore(20);
-        ClientHttpRequestInterceptor concurrencyInterceptor = (request, body, execution) -> {
-            try {
-                concurrencyLimiter.acquire();
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new IOException("Interrupted while waiting for concurrency permit", e);
-            }
-            try {
-                return execution.execute(request, body);
-            } finally {
-                concurrencyLimiter.release();
-            }
-        };
+        ConcurrencyInterceptor concurrencyInterceptor = new ConcurrencyInterceptor(CONCURRENCY_LIMIT);
 
         // Interceptor 실행 순서 (등록 순서 = 호출 순서, 첫번째가 가장 바깥):
         // 1. retryInterceptor (가장 바깥 - 429/5xx/IOException 재시도)
@@ -78,19 +68,25 @@ public class RiotApiConfig {
                 .requestInterceptor(rateLimitInterceptor)
                 .requestInterceptor(logRequest())
                 .requestInterceptor(concurrencyInterceptor)
-                .defaultStatusHandler(status -> status.value() == 404, (request, response) -> {
-                    throw new RiotClientNotFoundException(
-                            response.getStatusCode(), response.getStatusText(), LogLevel.WARN);
-                })
-                .defaultStatusHandler(HttpStatusCode::is4xxClientError, (request, response) -> {
-                    throw new RiotClientException(
-                            response.getStatusCode(), response.getStatusText(), LogLevel.WARN);
-                })
-                .defaultStatusHandler(HttpStatusCode::is5xxServerError, (request, response) -> {
-                    log.warn("5xx error headers: {}", response.getHeaders());
-                    throw new RiotServerException(response.getStatusCode(), response.getStatusText());
-                })
+                .defaultStatusHandler(status -> status.value() == 404, this::handleNotFound)
+                .defaultStatusHandler(HttpStatusCode::is4xxClientError, this::handleClientError)
+                .defaultStatusHandler(HttpStatusCode::is5xxServerError, this::handleServerError)
                 .build();
+    }
+
+    private void handleNotFound(HttpRequest request, ClientHttpResponse response) throws IOException {
+        throw new RiotClientNotFoundException(
+                response.getStatusCode(), response.getStatusText(), LogLevel.WARN);
+    }
+
+    private void handleClientError(HttpRequest request, ClientHttpResponse response) throws IOException {
+        throw new RiotClientException(
+                response.getStatusCode(), response.getStatusText(), LogLevel.WARN);
+    }
+
+    private void handleServerError(HttpRequest request, ClientHttpResponse response) throws IOException {
+        log.warn("5xx error headers: {}", response.getHeaders());
+        throw new RiotServerException(response.getStatusCode(), response.getStatusText());
     }
 
     private ClientHttpRequestInterceptor logRequest() {

--- a/infra/riot-client/src/main/java/com/mmrtr/lol/infra/riot/interceptor/ConcurrencyInterceptor.java
+++ b/infra/riot-client/src/main/java/com/mmrtr/lol/infra/riot/interceptor/ConcurrencyInterceptor.java
@@ -1,0 +1,34 @@
+package com.mmrtr.lol.infra.riot.interceptor;
+
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+
+import java.io.IOException;
+import java.util.concurrent.Semaphore;
+
+public class ConcurrencyInterceptor implements ClientHttpRequestInterceptor {
+
+    private final Semaphore permits;
+
+    public ConcurrencyInterceptor(int maxConcurrency) {
+        this.permits = new Semaphore(maxConcurrency);
+    }
+
+    @Override
+    public ClientHttpResponse intercept(HttpRequest request, byte[] body,
+            ClientHttpRequestExecution execution) throws IOException {
+        try {
+            permits.acquire();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while waiting for concurrency permit", e);
+        }
+        try {
+            return execution.execute(request, body);
+        } finally {
+            permits.release();
+        }
+    }
+}

--- a/infra/riot-client/src/main/java/com/mmrtr/lol/infra/riot/interceptor/RetryInterceptor.java
+++ b/infra/riot-client/src/main/java/com/mmrtr/lol/infra/riot/interceptor/RetryInterceptor.java
@@ -61,11 +61,11 @@ public class RetryInterceptor implements ClientHttpRequestInterceptor {
                         recordExhausted();
                         throw new RiotRateLimitException(retryAfter, status, "Riot rate limit exhausted", LogLevel.WARN);
                     }
-                    long base = retryAfter.isZero() ? exponentialBackoffMs(attempt) : retryAfter.toMillis();
-                    log.warn("Riot 429 — attempt {}/{}, Retry-After={}s, sleep base={}ms",
-                            attempt, MAX_ATTEMPTS, retryAfter.toSeconds(), base);
                     closeQuietly(response);
-                    sleepOrAbort(jitter(cap(base)));
+                    long sleepMs = computeBackoffMs(attempt, retryAfter);
+                    log.warn("Riot 429 — attempt {}/{}, Retry-After={}s, sleep={}ms",
+                            attempt, MAX_ATTEMPTS, retryAfter.toSeconds(), sleepMs);
+                    sleepOrAbort(sleepMs);
                     continue;
                 }
 
@@ -74,9 +74,11 @@ public class RetryInterceptor implements ClientHttpRequestInterceptor {
                         recordExhausted();
                         return response;
                     }
-                    log.warn("Riot 5xx — attempt {}/{}, status={}", attempt, MAX_ATTEMPTS, status.value());
                     closeQuietly(response);
-                    sleepOrAbort(jitter(cap(exponentialBackoffMs(attempt))));
+                    long sleepMs = computeBackoffMs(attempt, null);
+                    log.warn("Riot 5xx — attempt {}/{}, status={}, sleep={}ms",
+                            attempt, MAX_ATTEMPTS, status.value(), sleepMs);
+                    sleepOrAbort(sleepMs);
                     continue;
                 }
 
@@ -89,14 +91,10 @@ public class RetryInterceptor implements ClientHttpRequestInterceptor {
                     recordExhausted();
                     throw e;
                 }
-                Duration retryAfter = e.getRetryAfter();
-                long base = (retryAfter == null || retryAfter.isZero())
-                        ? exponentialBackoffMs(attempt)
-                        : retryAfter.toMillis();
-                log.warn("Riot RiotRateLimitException — attempt {}/{}, retryAfter={}ms, base={}ms",
-                        attempt, MAX_ATTEMPTS,
-                        retryAfter == null ? -1L : retryAfter.toMillis(), base);
-                sleepOrAbort(jitter(cap(base)));
+                long sleepMs = computeBackoffMs(attempt, e.getRetryAfter());
+                log.warn("Riot RiotRateLimitException — attempt {}/{}, sleep={}ms",
+                        attempt, MAX_ATTEMPTS, sleepMs);
+                sleepOrAbort(sleepMs);
             } catch (IOException e) {
                 if (e.getCause() instanceof InterruptedException) {
                     throw e;
@@ -105,11 +103,20 @@ public class RetryInterceptor implements ClientHttpRequestInterceptor {
                     recordExhausted();
                     throw e;
                 }
-                log.warn("Riot IOException — attempt {}/{}: {}", attempt, MAX_ATTEMPTS, e.getMessage());
-                sleepOrAbort(jitter(cap(exponentialBackoffMs(attempt))));
+                long sleepMs = computeBackoffMs(attempt, null);
+                log.warn("Riot IOException — attempt {}/{}, sleep={}ms: {}",
+                        attempt, MAX_ATTEMPTS, sleepMs, e.getMessage());
+                sleepOrAbort(sleepMs);
             }
         }
         throw new IllegalStateException("RetryInterceptor loop exited without resolution");
+    }
+
+    private long computeBackoffMs(int attempt, Duration retryAfter) {
+        long base = (retryAfter == null || retryAfter.isZero())
+                ? exponentialBackoffMs(attempt)
+                : retryAfter.toMillis();
+        return jitter(cap(base));
     }
 
     private Duration parseRetryAfter(String header) {

--- a/infra/riot-client/src/test/java/com/mmrtr/lol/infra/riot/interceptor/ConcurrencyInterceptorTest.java
+++ b/infra/riot-client/src/test/java/com/mmrtr/lol/infra/riot/interceptor/ConcurrencyInterceptorTest.java
@@ -1,0 +1,167 @@
+package com.mmrtr.lol.infra.riot.interceptor;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpResponse;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ConcurrencyInterceptorTest {
+
+    private static final HttpRequest REQUEST =
+            new TestHttpRequest(URI.create("http://example.com/x"), HttpMethod.GET);
+
+    @Test
+    @DisplayName("정상 흐름: execution 결과 그대로 반환")
+    void normal_flow_returns_execution_response() throws IOException {
+        ConcurrencyInterceptor interceptor = new ConcurrencyInterceptor(1);
+        ClientHttpResponse stub = new TestClientHttpResponse(HttpStatus.OK);
+        ClientHttpRequestExecution execution = (req, body) -> stub;
+
+        ClientHttpResponse response = interceptor.intercept(REQUEST, new byte[0], execution);
+
+        assertThat(response).isSameAs(stub);
+    }
+
+    @Test
+    @DisplayName("execution 예외 발생해도 permit 해제 — 후속 호출이 막히지 않음")
+    void permit_released_on_exception() throws IOException {
+        ConcurrencyInterceptor interceptor = new ConcurrencyInterceptor(1);
+        ClientHttpRequestExecution failing = (req, body) -> {
+            throw new IOException("boom");
+        };
+        ClientHttpResponse okStub = new TestClientHttpResponse(HttpStatus.OK);
+
+        assertThatThrownBy(() -> interceptor.intercept(REQUEST, new byte[0], failing))
+                .isInstanceOf(IOException.class);
+
+        ClientHttpResponse response = interceptor.intercept(REQUEST, new byte[0], (req, body) -> okStub);
+        assertThat(response).isSameAs(okStub);
+    }
+
+    @Test
+    @DisplayName("permit 만큼만 동시 실행: 2 permit, 3 요청 → 3번째는 대기")
+    void permits_bound_concurrent_requests() throws Exception {
+        ConcurrencyInterceptor interceptor = new ConcurrencyInterceptor(2);
+        CountDownLatch release = new CountDownLatch(1);
+        AtomicInteger inFlight = new AtomicInteger(0);
+        AtomicInteger peak = new AtomicInteger(0);
+        CountDownLatch entered = new CountDownLatch(2);
+
+        ClientHttpRequestExecution holding = (req, body) -> {
+            int current = inFlight.incrementAndGet();
+            peak.accumulateAndGet(current, Math::max);
+            entered.countDown();
+            try {
+                release.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IOException(e);
+            } finally {
+                inFlight.decrementAndGet();
+            }
+            return new TestClientHttpResponse(HttpStatus.OK);
+        };
+
+        ExecutorService executor = Executors.newFixedThreadPool(3);
+        try {
+            for (int i = 0; i < 3; i++) {
+                executor.submit(() -> interceptor.intercept(REQUEST, new byte[0], holding));
+            }
+
+            assertThat(entered.await(1, TimeUnit.SECONDS)).isTrue();
+            Thread.sleep(50);
+            assertThat(inFlight.get()).isEqualTo(2);
+
+            release.countDown();
+            executor.shutdown();
+            assertThat(executor.awaitTermination(2, TimeUnit.SECONDS)).isTrue();
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertThat(peak.get()).isEqualTo(2);
+    }
+
+    private static final class TestHttpRequest implements HttpRequest {
+        private final URI uri;
+        private final HttpMethod method;
+        private final HttpHeaders headers = new HttpHeaders();
+
+        TestHttpRequest(URI uri, HttpMethod method) {
+            this.uri = uri;
+            this.method = method;
+        }
+
+        @Override
+        public HttpMethod getMethod() {
+            return method;
+        }
+
+        @Override
+        public URI getURI() {
+            return uri;
+        }
+
+        @Override
+        public HttpHeaders getHeaders() {
+            return headers;
+        }
+
+        @Override
+        public Map<String, Object> getAttributes() {
+            return Map.of();
+        }
+    }
+
+    private static final class TestClientHttpResponse implements ClientHttpResponse {
+        private final HttpStatus status;
+        private final HttpHeaders headers = new HttpHeaders();
+
+        TestClientHttpResponse(HttpStatus status) {
+            this.status = status;
+        }
+
+        @Override
+        public HttpStatus getStatusCode() {
+            return status;
+        }
+
+        @Override
+        public String getStatusText() {
+            return status.getReasonPhrase();
+        }
+
+        @Override
+        public void close() {
+            // no-op
+        }
+
+        @Override
+        public InputStream getBody() {
+            return new ByteArrayInputStream(new byte[0]);
+        }
+
+        @Override
+        public HttpHeaders getHeaders() {
+            return headers;
+        }
+    }
+}


### PR DESCRIPTION
## 개요
RIOT API 클라이언트 인터셉터/설정의 순수 리팩토링. **행동 변경 0.**

기존에 develop 에 머지되지 못하고 로컬에만 남아있던 작업을 fresh develop 위에 cherry-pick 하여 정리한다 (충돌 0).

## 변경
- **`ConcurrencyInterceptor` 별도 클래스 추출** — RiotApiConfig 의 익명 람다(Semaphore) 제거, `CONCURRENCY_LIMIT=20` 상수 hoist, Semaphore 캡슐화
- **RiotApiConfig statusHandler 분리** — 404 / 4xx / 5xx 핸들러를 private method + method reference 로 분리
- **RetryInterceptor `computeBackoffMs(attempt, retryAfter)` 헬퍼 추출** — 429 / 5xx / RiotRateLimitException / IOException 4분기의 base + cap + jitter 계산 통일, 로그에 최종 sleepMs 표시
- **`ConcurrencyInterceptorTest` 3건 추가**

## 검증
- `:infra:riot-client:check` → BUILD SUCCESSFUL (checkstyle + 테스트)
- 기존 WireMock 8건 그대로 통과 + ConcurrencyInterceptorTest 3건
