### PR TITLE
chore: bootRun 시 루트 .env 자동 주입 (lol-server 정렬)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,25 @@ subprojects {
     bootRun {
         String activeProfile = System.properties['spring.profiles.active']
         systemProperty "spring.profiles.active", activeProfile
+
+        // 루트 .env 를 읽어 bootRun 프로세스 환경변수로 주입
+        def envFile = rootProject.file('.env')
+        if (envFile.exists()) {
+            envFile.readLines('UTF-8').each { line ->
+                def t = line.trim()
+                if (t.isEmpty() || t.startsWith('#')) return
+                if (t.startsWith('export ')) t = t.substring(7).trim()
+                int i = t.indexOf('=')
+                if (i <= 0) return
+                def key = t.substring(0, i).trim()
+                def value = t.substring(i + 1).trim()
+                if ((value.startsWith('"') && value.endsWith('"')) ||
+                    (value.startsWith("'") && value.endsWith("'"))) {
+                    value = value.substring(1, value.length() - 1)
+                }
+                environment key, value
+            }
+        }
     }
 
 }


### PR DESCRIPTION
## 변경
- `bootRun` 실행 시 루트 `.env` 파일을 읽어 프로세스 환경변수로 주입 (lol-server `build.gradle` 와 동일한 메커니즘으로 정렬)
- 파싱 규칙: 주석(`#`)·빈 줄 skip, `export ` 접두 제거, 첫 `=` 기준 key/value 분리, 양끝 따옴표 제거

## 이유
- 로컬 `./gradlew :module:app:application:bootRun` 실행 시 루트 `.env`(RIOT_API_KEY, DB_*, RABBITMQ_* 등)가 자동 주입되지 않던 점을 해소
- lol-server 와 로컬 실행 환경 구성 방식을 통일

## 검증
- `./gradlew help` 구성 단계 정상 통과 — `subprojects { bootRun { ... } }` 클로저 파싱/구성 확인
- diff는 `bootRun` 블록 추가(19줄)만 포함
