### PR TITLE
fix: bootRun에 spring.profiles.active 가드 추가 (.env 프로파일 적용, lol-server 정렬)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,9 @@ subprojects {
 
     bootRun {
         String activeProfile = System.properties['spring.profiles.active']
-        systemProperty "spring.profiles.active", activeProfile
+        if (activeProfile != null) {
+            systemProperty "spring.profiles.active", activeProfile
+        }
 
         // 루트 .env 를 읽어 bootRun 프로세스 환경변수로 주입
         def envFile = rootProject.file('.env')


### PR DESCRIPTION
## 문제
`-Dspring.profiles.active` 없이 루트 `.env`의 `SPRING_PROFILES_ACTIVE=local`에 의존해 `bootRun` 실행 시 `local` 프로파일이 활성화되지 않음.

## 원인
- `bootRun`이 `systemProperty "spring.profiles.active", activeProfile` 를 **무조건** 실행 → `-D` 미지정 시 `activeProfile == null` 이라 빈 시스템 프로퍼티가 설정됨.
- Spring 우선순위는 **시스템 프로퍼티 > 환경변수** 이므로, 이 빈 시스템 프로퍼티가 `.env`의 `SPRING_PROFILES_ACTIVE` 를 덮어써서 `local`이 무시됨.
- (#76 에서 `.env` 주입 블록만 옮기고 lol-server의 `if (activeProfile != null)` 가드를 누락한 것이 원인)

## 수정
- lol-server `build.gradle` 와 동일하게 `if (activeProfile != null)` 가드 추가 → `-D` 미지정 시 시스템 프로퍼티를 설정하지 않아 `.env`의 `SPRING_PROFILES_ACTIVE` 가 그대로 적용됨.

## 검증 (앱 미실행, Gradle 구성 단계 점검)
- `-D` 없음 → `bootRun` 의 `spring.profiles.active` 시스템 프로퍼티 **미설정**(`hasSysprop=false`), `SPRING_PROFILES_ACTIVE=local` 환경변수 주입 확인 → `local` 활성화됨
- `-Dspring.profiles.active=prod` → 시스템 프로퍼티 `prod` 로 설정(명시 `-D` 우선 동작 유지)
