### PR TITLE
fix(summoner): leagueId null 가드 — Riot league-v4 puuid 전환 대응

### DIFF
--- a/module/domain/summoner/src/main/java/com/mmrtr/lol/domain/summoner/application/usecase/SaveSummonerDataUseCase.java
+++ b/module/domain/summoner/src/main/java/com/mmrtr/lol/domain/summoner/application/usecase/SaveSummonerDataUseCase.java
@@ -26,11 +26,15 @@ public class SaveSummonerDataUseCase {
         summonerRepositoryPort.save(summoner);
 
         for (LeagueInfo leagueInfo : summoner.getLeagueInfos()) {
-            leagueRepositoryPort.saveIfAbsent(League.builder()
-                    .leagueId(leagueInfo.getLeagueId())
-                    .queue(leagueInfo.getQueueType())
-                    .tier(leagueInfo.getTier())
-                    .build());
+            // Riot league-v4 puuid 전환(2025)으로 leagueId 미제공 — League 저장만
+            // 건너뛴다. tier/rank/LP 는 아래 LeagueSummoner 가 보존한다.
+            if (leagueInfo.getLeagueId() != null) {
+                leagueRepositoryPort.saveIfAbsent(League.builder()
+                        .leagueId(leagueInfo.getLeagueId())
+                        .queue(leagueInfo.getQueueType())
+                        .tier(leagueInfo.getTier())
+                        .build());
+            }
 
             LeagueSummoner leagueSummoner = LeagueSummoner.builder()
                     .puuid(summoner.getPuuid())


### PR DESCRIPTION
## 배경

로컬 워킹트리에만 커밋되지 않은 채 남아 있던 수정입니다. 로컬 소스 정리 전에 유실을 막기 위해 PR 로 올립니다.

## 변경

Riot league-v4 의 puuid 전환(2025) 이후 응답에 `leagueId` 가 내려오지 않는 경우가 있어, `SaveSummonerDataUseCase` 가 `leagueId = null` 인 `League` 를 저장하고 있었습니다.

`leagueId` 가 null 이면 `League` 저장만 건너뛰도록 가드를 추가했습니다. tier/rank/LP 는 뒤이어 저장되는 `LeagueSummoner` 가 그대로 보존하므로 데이터 손실은 없습니다.

## 검증

- `./gradlew :module:domain:summoner:compileJava` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)